### PR TITLE
RFC5424 The Syslog Protocol - standardizing I-gate log output

### DIFF
--- a/src/syslog_utils.cpp
+++ b/src/syslog_utils.cpp
@@ -12,7 +12,7 @@ WiFiUDP udpClient;
 namespace SYSLOG_Utils {
 
     void log(String type, String packet, int rssi, float snr, int freqError) {
-        String syslogPacket = Config.callsign + " LoRa / ";
+        String syslogPacket = "<165>1 - " + Config.callsign + " LoRa" + " - - - "; //RFC5424 The Syslog Protocol
         if (Config.syslog.active && (stationMode==1 || stationMode==2 || (stationMode==5 && WiFi.status()==WL_CONNECTED))) {
             if (type == "APRSIS Tx") {
                 if (packet.indexOf(":>") > 10) {
@@ -55,7 +55,7 @@ namespace SYSLOG_Utils {
                     syslogPacket += type + " / " + packet;
                 }
             } else {
-                syslogPacket = "ERROR / Error in Syslog Packet";
+                syslogPacket = "<165>1 - ERROR LoRa - - - ERROR / Error in Syslog Packet"; //RFC5424 The Syslog Protocol
             }
             udpClient.beginPacket(Config.syslog.server.c_str(), Config.syslog.port);
             udpClient.write((const uint8_t*)syslogPacket.c_str(), syslogPacket.length());


### PR DESCRIPTION
Steps towards standardizing I-gate log output to comply with RFC 5424 for feeding a syslog server.

https://www.rfc-editor.org/rfc/rfc5424

I-gate log output (RFC 5424 format):

"<165>1 - YO8SSQ-15 LoRa - - - APRSIS Tx / StartUp STATUS / https://github.com/richonguzman/LoRa_APRS_iGate 2024.01.05"
"<165>1 - YO8SSQ-15 LoRa - - - LoRa Rx / GPS / YO8SSQ-1 / APLRT1 / WIDE1-1 / -64dBm / 4.50dB / -43Hz / 47.60001N / 26.3000E / 0.0km"

I have also discussed the proposed changes with YO3GWM.

73! YO8SSQ