### PR TITLE
Change filter to TX packet from APRS-IS

### DIFF
--- a/src/aprs_is_utils.cpp
+++ b/src/aprs_is_utils.cpp
@@ -156,6 +156,7 @@ namespace APRS_IS_Utils {
     }
   }
 
+  // We should take care of this page : https://aprs-is.net/IGateDetails.aspx
   void processAPRSISPacket(String packet) {
     String Sender, Message, Addressee, receivedMessage;
     if (!packet.isEmpty() && !packet.startsWith("#")){
@@ -213,7 +214,7 @@ namespace APRS_IS_Utils {
         }
         show_display(firstLine, secondLine, thirdLine, fourthLine, fifthLine, sixthLine, seventhLine, 0);
       }
-      else if (!(Addressee.indexOf("qAX") != -1 || Addressee.indexOf("RFONLY") != -1 || Addressee.indexOf("NOGATE") != -1 || Addressee.indexOf("TCPXX") != -1)) {
+      else if (Addressee.indexOf("qAX") == -1 && Addressee.indexOf("RFONLY") == -1 && Addressee.indexOf("NOGATE") == -1 && Addressee.indexOf("TCPXX") == -1) {
           if ((stationMode==2 || stationMode==5) && STATION_Utils::hasHeardSomeone()) {
               LoRa_Utils::sendNewPacket("APRS", LoRa_Utils::generatePacketSameContent(packet));
               display_toggle(true);

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -48,6 +48,7 @@ void Configuration::readFile(fs::FS &fs, const char *fileName) {
     aprs_is.server                  = data["aprs_is"]["server"].as<String>();
     aprs_is.port                    = data["aprs_is"]["port"].as<int>();
     aprs_is.reportingDistance       = data["aprs_is"]["reportingDistance"].as<int>();
+    aprs_is.filter                  = data["aprs_is"]["filter"].as<String>();
 
     loramodule.iGateFreq            = data["lora"]["iGateFreq"].as<long>();
     loramodule.digirepeaterTxFreq   = data["lora"]["digirepeaterTxFreq"].as<long>();

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -26,6 +26,7 @@ public:
   String  server;
   int     port;
   int     reportingDistance;
+  String  filter;
 };
 
 class LoraModule {

--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -56,12 +56,20 @@ namespace LoRa_Utils {
     Serial.println(newPacket);
   }
 
-  String generatePacket(String aprsisPacket) {
+  String generatePacketMessage(String aprsisPacket) {
     String firstPart, messagePart;
     aprsisPacket.trim();
     firstPart = aprsisPacket.substring(0, aprsisPacket.indexOf(","));
     messagePart = aprsisPacket.substring(aprsisPacket.indexOf("::")+2);
     return firstPart + ",TCPIP,WIDE1-1," + Config.callsign + "::" + messagePart;
+  }
+
+  String generatePacketSameContent(String aprsisPacket) {
+    String firstPart, messagePart;
+    aprsisPacket.trim();
+    firstPart = aprsisPacket.substring(0, aprsisPacket.indexOf(","));
+    messagePart = aprsisPacket.substring(aprsisPacket.indexOf(":"));
+    return firstPart + ",TCPIP," + Config.callsign + messagePart;
   }
 
   String receivePacket() {

--- a/src/lora_utils.h
+++ b/src/lora_utils.h
@@ -7,7 +7,8 @@ namespace LoRa_Utils {
 
 void setup();
 void sendNewPacket(const String &typeOfMessage, const String &newPacket);
-String generatePacket(String aprsisPacket);
+String generatePacketMessage(String aprsisPacket);
+String generatePacketSameContent(String aprsisPacket);
 String receivePacket();
 void changeFreqTx();
 void changeFreqRx();

--- a/src/station_utils.cpp
+++ b/src/station_utils.cpp
@@ -102,6 +102,7 @@ void updatePacketBuffer(String packet) {
 }
 
 bool hasHeardSomeone() {
+    deleteNotHeard();
     return !lastHeardStation.empty();
 }
 

--- a/src/station_utils.cpp
+++ b/src/station_utils.cpp
@@ -101,5 +101,9 @@ void updatePacketBuffer(String packet) {
   }
 }
 
+bool hasHeardSomeone() {
+    return !lastHeardStation.empty();
+}
+
 
 }

--- a/src/station_utils.h
+++ b/src/station_utils.h
@@ -10,6 +10,7 @@ void updateLastHeard(String station);
 bool wasHeard(String station);
 void checkBuffer();
 void updatePacketBuffer(String packet);
+bool hasHeardSomeone();
 
 }
 


### PR DESCRIPTION
IGate will TX packet from APRS-IS server.

I changed the default filter to `"r/" + String(currentWiFi->latitude, 7) + "/" + String(currentWiFi->longitude, 7) + "/" + String(Config.aprs_is.reportingDistance)`
In JSON, I set a new property in `aprs_is` call `filter` which override the default one by the user one.

TX only occured for packet without _TCP, qAR, NOGATE, RFONLY_ **and if the IGate has heard someone from RF during the `rememberStationTime`**