### PR TITLE
Change input type of password like fields

### DIFF
--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -204,7 +204,7 @@
                                         >Password</label
                                     >
                                     <input
-                                        type="text"
+                                        type="password"
                                         name="wifi.autoAP.password"
                                         id="wifi.autoAP.password"
                                         class="form-control"
@@ -364,7 +364,7 @@
                                             >Passcode</label
                                         >
                                         <input
-                                            type="text"
+                                            type="password"
                                             name="aprs_is.passcode"
                                             id="aprs_is.passcode"
                                             class="form-control"
@@ -572,7 +572,7 @@
                                         >Password</label
                                     >
                                     <input
-                                        type="text"
+                                        type="password"
                                         name="ota.password"
                                         id="ota.password"
                                         class="form-control"

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -99,7 +99,7 @@ function loadSettings(settings) {
                     <label for="${attributeName}.ssid">SSID</label>
                   </div>
                   <div class="form-floating col-6 col-md-3 px-1 mb-2">
-                    <input type="text" class="form-control form-control-sm" name="${attributeName}.password" id="${attributeName}.password" value="${network.password}">
+                    <input type="password" class="form-control form-control-sm" name="${attributeName}.password" id="${attributeName}.password" value="${network.password}">
                     <label for="${attributeName}.password">Passphrase</label>
                   </div>
                   <div class="col-4 col-md-2 form-floating px-1 mb-2">


### PR DESCRIPTION
A basic PR to change the input type of password like fields to password instead of text. Good, if you want to share screenshots.