### PR TITLE
TX every packet from APRS-IS (not only message)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ default_envs = ttgo-lora32-v21
 platform = espressif32 @ 6.3.1
 framework = arduino
 monitor_speed = 115200
+upload_speed = 921600
 board_build.embed_files = 
 	data_embed/index.html.gz
 	data_embed/style.css.gz

--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -125,12 +125,20 @@ namespace LoRa_Utils {
         ignorePacket = true;
     }
 
-    String generatePacket(String aprsisPacket) {
+    String generatePacketMessage(String aprsisPacket) {
         String firstPart, messagePart;
         aprsisPacket.trim();
         firstPart = aprsisPacket.substring(0, aprsisPacket.indexOf(","));
         messagePart = aprsisPacket.substring(aprsisPacket.indexOf("::") + 2);
         return firstPart + ",TCPIP,WIDE1-1," + Config.callsign + "::" + messagePart;
+    }
+
+    String generatePacketSameContent(String aprsisPacket) {
+        String firstPart, messagePart;
+        aprsisPacket.trim();
+        firstPart = aprsisPacket.substring(0, aprsisPacket.indexOf(","));
+        messagePart = aprsisPacket.substring(aprsisPacket.indexOf(":"));
+        return firstPart + ",TCPIP," + Config.callsign + messagePart;
     }
 
     String packetSanitization(String packet) {

--- a/src/lora_utils.h
+++ b/src/lora_utils.h
@@ -8,7 +8,8 @@ namespace LoRa_Utils {
 
     void setup();
     void sendNewPacket(const String &typeOfMessage, const String &newPacket);
-    String generatePacket(String aprsisPacket);
+    String generatePacketMessage(String aprsisPacket);
+    String generatePacketSameContent(String aprsisPacket);
     String packetSanitization(String packet);
     String receivePacket();
     void changeFreqTx();

--- a/src/station_utils.cpp
+++ b/src/station_utils.cpp
@@ -101,4 +101,9 @@ namespace STATION_Utils {
         }
     }
 
+    bool hasHeardSomeone() {
+        deleteNotHeard();
+        return !lastHeardStation.empty();
+    }
+
 }

--- a/src/station_utils.h
+++ b/src/station_utils.h
@@ -11,7 +11,7 @@ namespace STATION_Utils {
     bool wasHeard(String station);
     void checkBuffer();
     void updatePacketBuffer(String packet);
-
+    bool hasHeardSomeone();
 }
 
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -100,8 +100,6 @@ namespace Utils {
         if (beaconUpdate) {
             display_toggle(true);
 
-            Utils::println("-- Sending Beacon to APRSIS --");
-
             STATION_Utils::deleteNotHeard();
 
             activeStations();
@@ -135,6 +133,8 @@ namespace Utils {
                    
                 seventhLine = "     listening...";
 
+                Utils::println("-- Sending Beacon to APRSIS --");
+
                 APRS_IS_Utils::upload(beaconPacket);
             }
 
@@ -142,6 +142,8 @@ namespace Utils {
                 show_display(firstLine, secondLine, thirdLine, fourthLine, fifthLine, sixthLine, "SENDING DIGI BEACON", 0);
 
                 seventhLine = "     listening...";
+
+                Utils::println("-- Sending Beacon to RF --");
 
                 LoRa_Utils::sendNewPacket("APRS", secondaryBeaconPacket);
             }


### PR DESCRIPTION
Change in `processAPRSISPacket` to TX packet from APRS-IS **which are not message** (such as position of APRS AFSK around).

If LoRa Rx is enabled, TX only if we heard a station in the timing `rememberStationTime`.
If LoRa Rx is disabled, TX every 30 seconds.

- Change `upload_speed` (speed up and less error on my side)
- Change Serial log for "Sending Beacon" which were wrong