### PR TITLE
Added ADC readings based on stored Vref for TTGO lora32 2.1. 

### DIFF
--- a/data/igate_conf.json
+++ b/data/igate_conf.json
@@ -82,5 +82,6 @@
         "backupDigiMode": false,
         "rebootMode": false,
         "rebootModeTime": 6
-    }
+    },
+    "personalNote": ""
 }

--- a/data/igate_conf.json
+++ b/data/igate_conf.json
@@ -52,7 +52,9 @@
         "sendExternalVoltage": false,
         "externalVoltagePin": 34,
         "monitorExternalVoltage": false,
-        "externalSleepVoltage": 10.9
+        "externalSleepVoltage": 10.9,
+        "externalR1": 100,
+        "externalR2": 27
 	},
     "bme": {
         "active": false,

--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -989,6 +989,15 @@
                                                 >
                                             </div>
                                         </div>
+                                        <div class="col">
+                                            <label for="battery.externalR1" class="form-label">External Voltage divider R1</label>
+                                            <div class="input-group">
+                                                <input type="number" name="battery.externalR1"
+                                                    id="battery.externalR1" placeholder="100" class="form-control"
+                                                    step="0.1" min="1" max="1000" />
+                                                <span class="input-group-text">kOhm</span>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="col-6">
                                         <div class="form-floating col-7">
@@ -1036,6 +1045,13 @@
                                                 <span class="input-group-text"
                                                     >volts</span
                                                 >
+                                            </div>
+                                            <div class="col">
+                                                <label for="battery.externalR2" class="form-label">External Voltage divider R2</label>
+                                                <div class="input-group">
+                                                    <input type="number" name="battery.externalR2" id="battery.externalR2" placeholder="27" class="form-control" step="0.1" min="1" max="1000" />
+                                                    <span class="input-group-text">kOhm</span>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
@@ -1339,7 +1355,7 @@
                                                 type="number"
                                                 name="other.rebootModeTime"
                                                 id="other.rebootModeTime"
-                                                placeholder="0"
+                                                placeholder="6"
                                                 class="form-control"
                                                 step="6"
                                                 min="6"

--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -109,7 +109,8 @@
                                 <small
                                     >Add your ham callsign and SSID. Optionally,
                                     you can leave a comment describing your
-                                    station.</small
+                                    station. In the bottom there is a field for
+                                    personal note that can only be seen in WEB GUI.</small
                                 >
                             </div>
                             <div class="col-lg-9 col-sm-12">
@@ -235,6 +236,20 @@
                                             id="beacon.longitude"
                                             placeholder="-70.613"
                                             class="form-control"
+                                        />
+                                    </div>
+                                    <div class="col-12 mt-3">
+                                        <label
+                                            for="personalNote"
+                                            class="form-label"
+                                            >Personal Note</label
+                                        >
+                                        <input
+                                            type="text"
+                                            name="personalNote"
+                                            id="personalNote"
+                                            class="form-control"
+                                            placeholder="A Couple of words."
                                         />
                                     </div>
                                 </div>

--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -940,7 +940,9 @@
                                     </svg>
                                     Battery
                                 </h5>
-                                <small>Battery Monitor & Health</small>
+                                <small>Battery Monitor & Health <br>
+                                Max Voltage on input pin is 3.3V.
+                                Calculate voltage divider accordingly.</small>
                             </div>
                             <div class="col-9 mt-2">
                                 <div class="row mt-2">
@@ -1008,7 +1010,7 @@
                                             <label for="battery.externalR1" class="form-label">External Voltage divider R1</label>
                                             <div class="input-group">
                                                 <input type="number" name="battery.externalR1"
-                                                    id="battery.externalR1" placeholder="100" class="form-control"
+                                                    id="battery.externalR1" placeholder="R1" class="form-control"
                                                     step="0.1" min="1" max="1000" />
                                                 <span class="input-group-text">kOhm</span>
                                             </div>
@@ -1064,7 +1066,7 @@
                                             <div class="col">
                                                 <label for="battery.externalR2" class="form-label">External Voltage divider R2</label>
                                                 <div class="input-group">
-                                                    <input type="number" name="battery.externalR2" id="battery.externalR2" placeholder="27" class="form-control" step="0.1" min="1" max="1000" />
+                                                    <input type="number" name="battery.externalR2" id="battery.externalR2" placeholder="R2" class="form-control" step="0.1" min="1" max="1000" />
                                                     <span class="input-group-text">kOhm</span>
                                                 </div>
                                             </div>

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -284,8 +284,18 @@ const externalVoltagePinInput = document.querySelector(
     'input[name="battery.externalVoltagePin"]'
 );
 
+const externalR1 = document.querySelector(
+    'input[name="battery.externalR1"]'
+);
+
+const externalR2 = document.querySelector(
+    'input[name="battery.externalR2"]'
+);
+
 sendExternalVoltageCheckbox.addEventListener("change", function () {
     externalVoltagePinInput.disabled = !this.checked;
+    externalR1.disabled = !this.checked;
+    externalR2.disabled = !this.checked;
 });
 
 document.querySelector(".new button").addEventListener("click", function () {

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -162,6 +162,8 @@ function loadSettings(settings) {
     document.getElementById("battery.internalSleepVoltage").value       = settings.battery.internalSleepVoltage.toFixed(1);
     document.getElementById("battery.sendExternalVoltage").checked      = settings.battery.sendExternalVoltage;
     document.getElementById("battery.externalVoltagePin").value         = settings.battery.externalVoltagePin;
+    document.getElementById("battery.externalR1").value                 = settings.battery.externalR1;
+    document.getElementById("battery.externalR2").value                 = settings.battery.externalR2;
     document.getElementById("battery.monitorExternalVoltage").checked   = settings.battery.monitorExternalVoltage;
     document.getElementById("battery.externalSleepVoltage").value       = settings.battery.externalSleepVoltage.toFixed(1);
     

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -79,7 +79,7 @@ function loadSettings(settings) {
     document.getElementById("beacon.path").value                        = settings.beacon.path;
     document.getElementById("beacon.symbol").value                      = settings.beacon.symbol;
     document.getElementById("beacon.overlay").value                     = settings.beacon.overlay;
-
+    document.getElementById("personalNote").value                       = settings.personalNote;
     document.getElementById("action.symbol").value                      = settings.beacon.overlay + settings.beacon.symbol;
 
     document.querySelector(".list-networks").innerHTML                  = "";
@@ -273,8 +273,9 @@ function toggleFields() {
         'input[name="battery.externalVoltagePin"]'
     );
 
-    externalVoltagePinInput.disabled =
-        !sendExternalVoltageCheckbox.checked;
+    externalVoltagePinInput.disabled = !sendExternalVoltageCheckbox.checked;
+    externalR1.disabled = !sendExternalVoltageCheckbox.checked;
+    externalR2.disabled = !sendExternalVoltageCheckbox.checked;
 }
 
 const sendExternalVoltageCheckbox = document.querySelector(

--- a/src/LoRa_APRS_iGate.cpp
+++ b/src/LoRa_APRS_iGate.cpp
@@ -111,6 +111,12 @@ void setup() {
             Config.loramodule.rxActive = false;
         }
     #endif
+
+    #ifdef TTGO_T_LORA32_V2_1
+    BATTERY_Utils::adc_calibration_init();
+    BATTERY_Utils::configADC();
+    #endif
+
     WIFI_Utils::setup();
     SYSLOG_Utils::setup();
     BME_Utils::setup();

--- a/src/battery_utils.cpp
+++ b/src/battery_utils.cpp
@@ -10,7 +10,9 @@
 
 #define EXTCHAN ADC1_CHANNEL_6
 #define INTCHAN ADC1_CHANNEL_7
-#define BATTDIVIDER 2 // Internal Battery Divider ratio
+#ifdef TTGO_T_LORA32_V2_1
+    #define INTBATTDIVIDER 2 // Internal Battery Divider ratio
+#endif
 
 #if CONFIG_IDF_TARGET_ESP32
 #define ADC_EXAMPLE_CALI_SCHEME ESP_ADC_CAL_VAL_EFUSE_VREF
@@ -99,8 +101,8 @@ namespace BATTERY_Utils {
             #else
                 #ifdef TTGO_T_LORA32_V2_1
                     if (cali_enable){
-                        voltage = esp_adc_cal_raw_to_voltage(sampleSum / 100, &adc_chars) * BATTDIVIDER;
-                        return voltage / 1000;
+                        voltage = esp_adc_cal_raw_to_voltage(sampleSum / 100, &adc_chars) * INTBATTDIVIDER; // in mV
+                        voltage /=1000;
                     }
                     else{
                         voltage = (2 * (sampleSum/100) * adcReadingTransformation) + voltageDividerCorrection;
@@ -138,7 +140,8 @@ namespace BATTERY_Utils {
         #ifdef TTGO_T_LORA32_V2_1
             if (cali_enable)
         {
-            voltage = (esp_adc_cal_raw_to_voltage(sampleSum / 100, &adc_chars) * ((R1 + R2) / R2))/1000;
+            voltage = esp_adc_cal_raw_to_voltage(sampleSum / 100, &adc_chars) * ((R1 + R2) / R2); // in mV
+            voltage /= 1000;
         }
         else{
             voltage = ((((sampleSum/100)* adcReadingTransformation) + readingCorrection) * ((R1+R2)/R2)) - multiplyCorrection;

--- a/src/battery_utils.h
+++ b/src/battery_utils.h
@@ -10,6 +10,8 @@ namespace BATTERY_Utils {
     float   checkExternalVoltage();
     void    checkIfShouldSleep(); // ????
     void    startupBatteryHealth();
+    bool    adc_calibration_init();
+    void    configADC();
 
 }
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -73,6 +73,9 @@ void Configuration::writeFile() {
     data["battery"]["externalVoltagePin"]       = battery.externalVoltagePin;
     data["battery"]["monitorExternalVoltage"]   = battery.monitorExternalVoltage;
     data["battery"]["externalSleepVoltage"]     = battery.externalSleepVoltage;
+    data["battery"]["externalR1"]               = battery.externalR1;
+    data["battery"]["externalR2"]               = battery.externalR2;
+    
 
     data["bme"]["active"]                   = bme.active;
     data["bme"]["heightCorrection"]         = bme.heightCorrection;
@@ -142,6 +145,8 @@ bool Configuration::readFile() {
         battery.externalVoltagePin      = data["battery"]["externalVoltagePin"].as<int>();
         battery.monitorExternalVoltage  = data["battery"]["monitorExternalVoltage"].as<bool>();
         battery.externalSleepVoltage    = data["battery"]["externalSleepVoltage"].as<float>();
+        battery.externalR1              = data["battery"]["externalR1"].as<float>();
+        battery.externalR2              = data["battery"]["externalR2"].as<float>();
 
         aprs_is.passcode                = data["aprs_is"]["passcode"].as<String>();
         aprs_is.server                  = data["aprs_is"]["server"].as<String>();
@@ -341,6 +346,8 @@ void Configuration::init() {
     battery.externalVoltagePin      = 34;
     battery.monitorExternalVoltage  = false;
     battery.externalSleepVoltage    = 3.0;
+    battery.externalR1              = 100.0;
+    battery.externalR2              = 27.0;
 
     lowPowerMode                = false;
     lowVoltageCutOff            = 0;

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -100,7 +100,9 @@ void Configuration::writeFile() {
     data["other"]["backupDigiMode"]         = backupDigiMode;    
 
     data["other"]["lowPowerMode"]           = lowPowerMode;
-    data["other"]["lowVoltageCutOff"]       = lowVoltageCutOff;    
+    data["other"]["lowVoltageCutOff"]       = lowVoltageCutOff;
+
+    data["personalNote"]                    = personalNote;    
 
     serializeJson(data, configFile);
 
@@ -183,6 +185,8 @@ bool Configuration::readFile() {
 
         rebootMode                      = data["other"]["rebootMode"].as<bool>();
         rebootModeTime                  = data["other"]["rebootModeTime"].as<int>();
+
+        personalNote    	            = data["personalNote"].as<String>();
 
         int stationMode                 = data["stationMode"].as<int>(); // deprecated but need to specify config version
 
@@ -335,7 +339,6 @@ void Configuration::init() {
     ota.username                = "";
     ota.password                = "";
 
-    
     rememberStationTime         = 30;
 
     battery.sendInternalVoltage     = false;
@@ -356,6 +359,8 @@ void Configuration::init() {
 
     rebootMode                  = false;
     rebootModeTime              = 0;
+
+    personalNote                = "";
 
     Serial.println("All is Written!");
 }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -75,6 +75,8 @@ public:
     int     externalVoltagePin;
     bool    monitorExternalVoltage;
     float   externalSleepVoltage;
+    float   externalR1;
+    float   externalR2;
 };
 
 class BME {

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -116,6 +116,7 @@ public:
     bool                    backupDigiMode;
     bool                    rebootMode;
     int                     rebootModeTime;
+    String                  personalNote;
     std::vector<WiFi_AP>    wifiAPs;
     WiFi_Auto_AP            wifiAutoAP;
     BEACON                  beacon;

--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -141,14 +141,16 @@ namespace WEB_Utils {
 
         Config.battery.sendInternalVoltage      = request->hasParam("battery.sendInternalVoltage", true);
         Config.battery.monitorInternalVoltage   = request->hasParam("battery.monitorInternalVoltage", true);
-        Config.battery.internalSleepVoltage = request->getParam("battery.internalSleepVoltage", true)->value().toFloat();
+        Config.battery.internalSleepVoltage     = request->getParam("battery.internalSleepVoltage", true)->value().toFloat();
 
         Config.battery.sendExternalVoltage      = request->hasParam("battery.sendExternalVoltage", true);
         if (Config.battery.sendExternalVoltage) {
             Config.battery.externalVoltagePin   = request->getParam("battery.externalVoltagePin", true)->value().toInt();
         }
         Config.battery.monitorExternalVoltage   = request->hasParam("battery.monitorExternalVoltage", true);
-        Config.battery.externalSleepVoltage = request->getParam("battery.externalSleepVoltage", true)->value().toFloat();
+        Config.battery.externalSleepVoltage     = request->getParam("battery.externalSleepVoltage", true)->value().toFloat();
+        Config.battery.externalR1               = request->getParam("battery.externalR1", true)->value().toFloat();
+        Config.battery.externalR2               = request->getParam("battery.externalR2", true)->value().toFloat();
 
 
         Config.bme.active                   = request->hasParam("bme.active", true);

--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -181,7 +181,7 @@ namespace WEB_Utils {
         Config.ota.password                 = request->getParam("ota.password", true)->value();
 
 
-        Config.rememberStationTime              = request->getParam("other.rememberStationTime", true)->value().toInt();
+        Config.rememberStationTime          = request->getParam("other.rememberStationTime", true)->value().toInt();
 
        
         Config.backupDigiMode               = request->hasParam("other.backupDigiMode", true);
@@ -189,6 +189,8 @@ namespace WEB_Utils {
 
         Config.lowPowerMode                 = request->hasParam("other.lowPowerMode", true);
         Config.lowVoltageCutOff             = request->getParam("other.lowVoltageCutOff", true)->value().toDouble();
+
+        Config.personalNote                 = request->getParam("personalNote", true)->value();
 
         Config.writeFile();
 

--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -29,7 +29,6 @@ extern const char web_bootstrap_js[] asm("_binary_data_embed_bootstrap_js_gz_sta
 extern const char web_bootstrap_js_end[] asm("_binary_data_embed_bootstrap_js_gz_end");
 extern const size_t web_bootstrap_js_len = web_bootstrap_js_end - web_bootstrap_js;
 
-
 namespace WEB_Utils {
 
     AsyncWebServer server(80);
@@ -160,33 +159,25 @@ namespace WEB_Utils {
             Config.beacon.symbol = "_";
         }
 
-
         Config.syslog.active                = request->hasParam("syslog.active", true);
         if (Config.syslog.active) {
-            Config.syslog.server    = request->getParam("syslog.server", true)->value();
-            Config.syslog.port      = request->getParam("syslog.port", true)->value().toInt();
+            Config.syslog.server            = request->getParam("syslog.server", true)->value();
+            Config.syslog.port              = request->getParam("syslog.port", true)->value().toInt();
         }
         
+        Config.tnc.enableServer             = request->hasParam("tnc.enableServer", true);
+        Config.tnc.enableSerial             = request->hasParam("tnc.enableSerial", true);
+        Config.tnc.acceptOwn                = request->hasParam("tnc.acceptOwn", true);
 
-        Config.tnc.enableServer         = request->hasParam("tnc.enableServer", true);
-        Config.tnc.enableSerial         = request->hasParam("tnc.enableSerial", true);
-        Config.tnc.acceptOwn            = request->hasParam("tnc.acceptOwn", true);
-
-        
         Config.rebootMode                   = request->hasParam("other.rebootMode", true);
         Config.rebootModeTime               = request->getParam("other.rebootModeTime", true)->value().toInt();
-        
 
         Config.ota.username                 = request->getParam("ota.username", true)->value();
         Config.ota.password                 = request->getParam("ota.password", true)->value();
 
-
         Config.rememberStationTime          = request->getParam("other.rememberStationTime", true)->value().toInt();
 
-       
         Config.backupDigiMode               = request->hasParam("other.backupDigiMode", true);
-
-
         Config.lowPowerMode                 = request->hasParam("other.lowPowerMode", true);
         Config.lowVoltageCutOff             = request->getParam("other.lowVoltageCutOff", true)->value().toDouble();
 

--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -145,13 +145,12 @@ namespace WEB_Utils {
         Config.battery.sendExternalVoltage      = request->hasParam("battery.sendExternalVoltage", true);
         if (Config.battery.sendExternalVoltage) {
             Config.battery.externalVoltagePin   = request->getParam("battery.externalVoltagePin", true)->value().toInt();
+            Config.battery.externalR1           = request->getParam("battery.externalR1", true)->value().toFloat();
+            Config.battery.externalR2           = request->getParam("battery.externalR2", true)->value().toFloat();
         }
         Config.battery.monitorExternalVoltage   = request->hasParam("battery.monitorExternalVoltage", true);
         Config.battery.externalSleepVoltage     = request->getParam("battery.externalSleepVoltage", true)->value().toFloat();
-        Config.battery.externalR1               = request->getParam("battery.externalR1", true)->value().toFloat();
-        Config.battery.externalR2               = request->getParam("battery.externalR2", true)->value().toFloat();
-
-
+        
         Config.bme.active                   = request->hasParam("bme.active", true);
         Config.bme.heightCorrection         = request->getParam("bme.heightCorrection", true)->value().toInt();
         Config.bme.temperatureCorrection    = request->getParam("bme.temperatureCorrection", true)->value().toFloat();


### PR DESCRIPTION
I have modified the code in a way that it uses "burned" Vref value from the chip for more accurate ADC readings.  I have done this in a way that this is used only on a LilyGo Lora32 v2.1 as I don't have any other boards at home. I think it should work with any ESP32 boards but needs to be tested. Voltage measurements are a bit more accurate.
This has been done based on esp-if examples on github. 

R1 and R2 values have also been added to the WEB GUI in case anybody has different voltage in front of voltage divider.

Personal Note field has been added to the WEB GUI.