### PR TITLE
Support modules with XTAL 

### DIFF
--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -50,7 +50,7 @@ namespace LoRa_Utils {
         if (state == RADIOLIB_ERR_NONE) {
             Utils::println("Initializing LoRa Module");
         } else {
-            Utils::println("Starting LoRa failed!");
+            Utils::println("Starting LoRa failed! State: " + String(state));
             while (true);
         }
         #if defined(HAS_SX1262) || defined(HAS_SX1268)

--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -43,6 +43,9 @@ namespace LoRa_Utils {
     void setup() {
         SPI.begin(RADIO_SCLK_PIN, RADIO_MISO_PIN, RADIO_MOSI_PIN);
         float freq = (float)Config.loramodule.rxFreq / 1000000;
+        #if defined(RADIO_HAS_XTAL)
+        radio.XTAL = true;
+        #endif
         int state = radio.begin(freq);
         if (state == RADIOLIB_ERR_NONE) {
             Utils::println("Initializing LoRa Module");


### PR DESCRIPTION
I making custom board for tracker and later mainly for iGate. I am using now SX1268 radio module which does not use TCXO but XTAL. https://www.aliexpress.com/item/1005005715303224.html

This add build time flag to tell RadioLib to use XTAL instead of TCXO.

Also one commit add error code from begin, which was helpful to se error -707