### PR TITLE
Add versionDate to web page footer.

### DIFF
--- a/tools/compress.py
+++ b/tools/compress.py
@@ -12,6 +12,18 @@ files = [
   'data_embed/favicon.png',
 ]
 
+string_to_find_str = "String"
+string_to_find_ver = "versionDate"
+
+with open('src/LoRa_APRS_iGate.cpp', encoding='utf-8') as cpp_file:
+  for line in cpp_file:
+    if string_to_find_str in line and string_to_find_ver in line:
+      start = line.find('"') + 1
+      end = line.find('"', start)
+      if start > 0 and end > start:
+        versionDate = line[start:end]
+        break
+
 for src in files:
   out = src + ".gz"
   
@@ -20,7 +32,7 @@ for src in files:
     content = f.read()
     
   if src == 'data_embed/index.html':
-    env_vars = env["BOARD"] + "<br>" + ','.join(env["BUILD_FLAGS"]).replace('-Werror -Wall,', '').replace(',-DELEGANTOTA_USE_ASYNC_WEBSERVER=1', '')
+    env_vars = env["BOARD"] + "<br>" + ','.join(env["BUILD_FLAGS"]).replace('-Werror -Wall,', '').replace(',-DELEGANTOTA_USE_ASYNC_WEBSERVER=1', '') + "<br>" + "Version date: " + versionDate
     current_date = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S') + " UTC"
     build_info = f'{env_vars}<br>Build date: {current_date}'.encode()
     


### PR DESCRIPTION
Display versionDate constant from src/LoRa_APRS_iGate.cpp in the web page footer together with build date. It is good to know when the firmware was built, but it's also good which version of the source code was used for it.

With help from S57RW