### PR TITLE
Correct logic of serial notifications for APRS-IS and RF beacons

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -112,8 +112,7 @@ namespace Utils {
             if (!Config.display.alwaysOn && Config.display.timeout != 0) {
                 displayToggle(true);
             }
-            Utils::println("-- Sending Beacon to APRSIS --");
-
+            
             STATION_Utils::deleteNotHeard();
 
             activeStations();
@@ -172,6 +171,7 @@ namespace Utils {
             }
 
             if (Config.aprs_is.active && Config.beacon.sendViaAPRSIS && !backUpDigiMode) {
+                Utils::println("-- Sending Beacon to APRSIS --");
                 displayShow(firstLine, secondLine, thirdLine, fourthLine, fifthLine, sixthLine, "SENDING IGATE BEACON", 0); 
                 seventhLine = "     listening...";
                 #ifdef HAS_A7670
@@ -182,6 +182,7 @@ namespace Utils {
             }
 
             if (Config.beacon.sendViaRF || backUpDigiMode) {
+                Utils::println("-- Sending Beacon to RF --");
                 displayShow(firstLine, secondLine, thirdLine, fourthLine, fifthLine, sixthLine, "SENDING DIGI BEACON", 0);
                 seventhLine = "     listening...";
                 STATION_Utils::addToOutputPacketBuffer(secondaryBeaconPacket);


### PR DESCRIPTION
Small fix to the debug messages to show if the beacon is sent to APRS-IS, RF or both.