### PR TITLE
Make AutoAP run only once after a reboot

### DIFF
--- a/src/aprs_is_utils.cpp
+++ b/src/aprs_is_utils.cpp
@@ -21,6 +21,7 @@ extern String               sixthLine;
 extern String               seventhLine;
 extern bool                 modemLoggedToAPRSIS;
 extern bool                 backUpDigiMode;
+extern bool                 WiFiAutoAPStarted;
 
 uint32_t lastRxTime         = millis();
 
@@ -72,10 +73,14 @@ namespace APRS_IS_Utils {
             wifiState = "OK";
         } else {
             if (backUpDigiMode) {
-                wifiState = "--";
-            } else {
+                wifiState = "BK";
+            } else if (WiFiAutoAPStarted){
                 wifiState = "AP";
-            }            
+            } 
+            else {
+                wifiState = "--";
+            }
+
             if (!Config.display.alwaysOn && Config.display.timeout != 0) {
                 displayToggle(true);
             }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -112,8 +112,7 @@ namespace Utils {
             if (!Config.display.alwaysOn && Config.display.timeout != 0) {
                 displayToggle(true);
             }
-            Utils::println("-- Sending Beacon to APRSIS --");
-
+            
             STATION_Utils::deleteNotHeard();
 
             activeStations();
@@ -172,6 +171,7 @@ namespace Utils {
             }
 
             if (Config.aprs_is.active && Config.beacon.sendViaAPRSIS && !backUpDigiMode) {
+                Utils::println("-- Sending Beacon to APRSIS --");
                 displayShow(firstLine, secondLine, thirdLine, fourthLine, fifthLine, sixthLine, "SENDING IGATE BEACON", 0); 
                 seventhLine = "     listening...";
                 #ifdef HAS_A7670
@@ -182,6 +182,7 @@ namespace Utils {
             }
 
             if (Config.beacon.sendViaRF || backUpDigiMode) {
+                Utils::println("-- Sending Beacon to RF --");
                 displayShow(firstLine, secondLine, thirdLine, fourthLine, fifthLine, sixthLine, "SENDING DIGI BEACON", 0);
                 seventhLine = "     listening...";
                 STATION_Utils::addToOutputPacketBuffer(secondaryBeaconPacket);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -35,6 +35,7 @@ extern int                  wxModuleType;
 extern bool                 backUpDigiMode;
 extern bool                 shouldSleepLowVoltage;
 extern bool                 transmitFlag;
+extern bool                 WiFiAutoAPStarted;
 
 bool        statusAfterBoot     = true;
 bool        beaconUpdate        = true;
@@ -69,11 +70,16 @@ namespace Utils {
     }
 
     String getLocalIP() {
-        if (!WiFiConnected) {
+        if (!WiFiConnected && WiFiAutoAPStarted) {
             return "IP :  192.168.4.1";
-        } else if (backUpDigiMode) {
+        } 
+        else if (backUpDigiMode) {
             return "- BACKUP DIGI MODE -";
-        } else {
+        } 
+        else if (!WiFiConnected) {
+            return "IP :  -";
+        }
+        else {
             return "IP :  " + String(WiFi.localIP()[0]) + "." + String(WiFi.localIP()[1]) + "." + String(WiFi.localIP()[2]) + "." + String(WiFi.localIP()[3]);
         }        
     }


### PR DESCRIPTION
Previously, AutoAP restarted immediately after the timeout, so it was effectively running all the time if wifi was absent or not configured.

With this change, If wifi goes away, AutoAP mode will run only once. After AutoAP timeout, code will check regularily if wifi returns and during checks the wifi card will be idle. If wifi is not configured, AutoAP will run only once and then keep card idle for lower power consumption.

Display is adjusted accordingly, with "Wifi: --" when the card is in idle mode and "Wifi: BK" in BACKUP DIGI MODE. 

This reduces idle current consumption on my Lora32 2.1_1.6 from approx. 85mA @12V (with AutoAP running) to 37mA (stopped wifi).