### PR TITLE
Set client hostname same as callsign.

### DIFF
--- a/src/wifi_utils.cpp
+++ b/src/wifi_utils.cpp
@@ -151,7 +151,7 @@ namespace WIFI_Utils {
     void setup() {
         if (Config.callsign.length() > 0) {
             WiFi.mode(WIFI_MODE_NULL);
-            WiFi.setHostname (Config.callsign.c_str());
+            WiFi.setHostname(Config.callsign.c_str());
         }
         startWiFi();
         btStop();

--- a/src/wifi_utils.cpp
+++ b/src/wifi_utils.cpp
@@ -149,6 +149,10 @@ namespace WIFI_Utils {
     }
 
     void setup() {
+        if (Config.callsign.length() > 0) {
+            WiFi.mode(WIFI_MODE_NULL);
+            WiFi.setHostname (Config.callsign.c_str());
+        }
         startWiFi();
         btStop();
     }


### PR DESCRIPTION
This changes the client hostname from ESP32-XXXXXX to Callsign. The idea is to make DHCP server log less confusing, as on a big network it can have many ESP32-XXXXXX entries.

Developed and tested together with S54B.