### PR TITLE
Prepare variants for better board manage

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,9 @@
 [platformio]
 default_envs = ttgo-lora32-v21
 
+extra_configs =
+  variants/*/platformio.ini
+
 [env]
 platform = espressif32 @ 6.7.0
 board_build.partitions = min_spiffs.csv


### PR DESCRIPTION
This PR introduce variants folder and include this folder in platformio.ini

That will make easier managing of existing and new boards. Also if someone add own board to platformio.ini and you will make changes, it will NOT conflict after this change, because it will be untracked new folder inside variants folder, so any changes to other boards (like now ePaper ones) will NOT cause conflicts during rebase to latest master

In next step is move all boards from platformio.ini to variants, but for now this is minimum to make possible to do for new boards. Old ones can be moved momentary.

There are lot of boards, so it will take lot of work to move them all. But since it is include not change, then it can be done one-by-one but not need to at once..

I will show in next PR example with moved few boards.