### PR TITLE
On EcoMode, defer sending the initial telemetry packets for one beacon.

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -195,7 +195,7 @@ namespace Utils {
         if (beaconUpdate) {
             if (!Config.display.alwaysOn && Config.display.timeout != 0) displayToggle(true);
 
-            if (sendStartTelemetry && Config.battery.sendVoltageAsTelemetry && !Config.wxsensor.active && (Config.battery.sendInternalVoltage || Config.battery.sendExternalVoltage)) {
+            if (sendStartTelemetry && Config.battery.sendVoltageAsTelemetry && !Config.wxsensor.active && (Config.battery.sendInternalVoltage || Config.battery.sendExternalVoltage) && (!Config.digi.ecoMode || lastBeaconTx > 0)) {
                 sendInitialTelemetryPackets();
             }
 


### PR DESCRIPTION
Rationale: when EcoMode is enabled, eventually running on battery, with very low energy available, do not waste it on sending the packets which set the UNIT, PARM and EQNS, but send directly the first beacon, then the status, as usual, and, if there is enough energy, send those packets before the second beacon.  That first beacon might be the only one to ride the radio waves before the device shuts down and might contain the internal and external voltages.  This would happen in remote solar powered digipeaters on very cloudy days.  Sending just one beacon might prove the device is alive and waiting for better days.

This is a part of the log of my station barely having energy for one beacon and wasting it:

```
2025-02-18 00:19:41 EET: YO3JAZ-8>APLRG1,WIDE1-1,qAR,YO3JAZ-10::YO3JAZ-8 :EQNS.0,0.01,0,0,0.02,0
2025-02-18 22:30:59 EET: YO3JAZ-8>APLRG1,WIDE1-1,qAR,YO3JAZ-10::YO3JAZ-8 :EQNS.0,0.01,0,0,0.02,0
2025-02-19 06:14:51 EET: YO3JAZ-8>APLRG1,WIDE1-1,qAR,YO3JAZ-10::YO3JAZ-8 :EQNS.0,0.01,0,0,0.02,0
2025-02-19 21:25:52 EET: YO3JAZ-8>APLRG1,WIDE1-1,qAR,YO3JAZ-10::YO3JAZ-8 :EQNS.0,0.01,0,0,0.02,0
```