### PR TITLE
Update tnc_utils.cpp

### DIFF
--- a/src/tnc_utils.cpp
+++ b/src/tnc_utils.cpp
@@ -4,6 +4,7 @@
 #include "configuration.h"
 #include "station_utils.h"
 #include "utils.h"
+#include "ESPmDNS.h"
 
 
 extern Configuration        Config;
@@ -27,6 +28,8 @@ namespace TNC_Utils {
         if (Config.tnc.enableServer && !Config.digi.ecoMode) {
             tncServer.stop();
             tncServer.begin();
+            MDNS.begin("kiss-tnc");
+            MDNS.addService("kiss-tnc", "tcp", 8001);
         }
     }
 


### PR DESCRIPTION
Announce tnc server so apps like aprs.fi iOS can find it (currently this app do not allow to set IP and port manually for tnc modem).