### PR TITLE
Update igate_conf.json

### DIFF
--- a/data/igate_conf.json
+++ b/data/igate_conf.json
@@ -37,7 +37,7 @@
         "spreadingFactor": 12,
         "signalBandwidth": 125000,
         "codingRate4": 5,
-        "power": 20,
+        "power": 10,
         "txActive": false,
         "rxActive": true
     },


### PR DESCRIPTION
Sane defaults.

In Europe maximum legal ERP is 10dBm 10% duty cycle for 433Mhz.

People installs this firmware inadvertently violating those legal limits (I know, every ham should be aware of limits and configure appropriately, but reallity is different).