### PR TITLE
Add support for TTGO T8 ESP32-S2 v1.1 board

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -29,10 +29,14 @@
         TFT_eSPI tft = TFT_eSPI(); 
         TFT_eSprite sprite  = TFT_eSprite(&tft);
 
-        #ifdef HELTEC_WIRELESS_TRACKER
+        #if defined(HELTEC_WIRELESS_TRACKER)
             #define bigSizeFont     2
             #define smallSizeFont   1
             #define lineSpacing     10
+        #elif defined(TTGO_T8_S2_DIY_LoRa)
+            #define bigSizeFont     2
+            #define smallSizeFont   1
+            #define lineSpacing     17
         #endif
         #if defined(TTGO_T_DECK_GPS) || defined(TTGO_T_DECK_PLUS)
             #define bigSizeFont     5
@@ -84,6 +88,8 @@ void displaySetup() {
             tft.fillScreen(TFT_BLACK);
             #if defined(TTGO_T_DECK_GPS) || defined(TTGO_T_DECK_PLUS)
                 sprite.createSprite(320,240);
+            #elif defined(TTGO_T8_S2_DIY_LoRa)
+                sprite.createSprite(240,135);
             #else
                 sprite.createSprite(160,80);
             #endif
@@ -178,6 +184,9 @@ void displayShow(const String& header, const String& line1, const String& line2,
             #if defined(TTGO_T_DECK_GPS) || defined(TTGO_T_DECK_PLUS)
                 sprite.fillRect(0, 0, 320, 43, redColor);
             #endif
+            #if defined(TTGO_T8_S2_DIY_LoRa)
+                sprite.fillRect(0, 0, 320, 25, redColor);
+            #endif
             sprite.setTextFont(0);
             sprite.setTextSize(bigSizeFont);
             sprite.setTextColor(TFT_WHITE, redColor);
@@ -242,6 +251,9 @@ void displayShow(const String& header, const String& line1, const String& line2,
             #endif
             #if defined(TTGO_T_DECK_GPS) || defined(TTGO_T_DECK_PLUS)
                 sprite.fillRect(0, 0, 320, 43, redColor);
+            #endif
+            #if defined(TTGO_T8_S2_DIY_LoRa)
+                sprite.fillRect(0, 0, 320, 27, redColor);
             #endif
             sprite.setTextFont(0);
             sprite.setTextSize(bigSizeFont);

--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -37,7 +37,12 @@ bool operationDone   = true;
 bool transmitFlag    = true;
 
 #ifdef HAS_SX1262
-    SX1262 radio = new Module(RADIO_CS_PIN, RADIO_DIO1_PIN, RADIO_RST_PIN, RADIO_BUSY_PIN);
+    #if defined(TTGO_T8_S2_DIY_LoRa) 
+        SPIClass loraSPI(FSPI);
+        SX1262 radio = new Module(RADIO_CS_PIN, RADIO_DIO1_PIN, RADIO_RST_PIN, RADIO_BUSY_PIN, loraSPI); 
+    #else
+        SX1262 radio = new Module(RADIO_CS_PIN, RADIO_DIO1_PIN, RADIO_RST_PIN, RADIO_BUSY_PIN);
+    #endif
 #endif
 #ifdef HAS_SX1268
     #if defined(LIGHTGATEWAY_1_0) || defined(LIGHTGATEWAY_PLUS_1_0)
@@ -68,13 +73,15 @@ namespace LoRa_Utils {
     }
 
     void setup() {
-        #if defined (LIGHTGATEWAY_1_0) || defined(LIGHTGATEWAY_PLUS_1_0)
-            pinMode(RADIO_VCC_PIN,OUTPUT);
-            digitalWrite(RADIO_VCC_PIN,HIGH);
+        #if defined (LIGHTGATEWAY_1_0) || defined(LIGHTGATEWAY_PLUS_1_0) || defined(TTGO_T8_S2_DIY_LoRa)
+            #if defined(RADIO_VCC_PIN)
+                pinMode(RADIO_VCC_PIN,OUTPUT);
+                digitalWrite(RADIO_VCC_PIN,HIGH);
+            #endif
             loraSPI.begin(RADIO_SCLK_PIN, RADIO_MISO_PIN, RADIO_MOSI_PIN, RADIO_CS_PIN);
-        #else
-            SPI.begin(RADIO_SCLK_PIN, RADIO_MISO_PIN, RADIO_MOSI_PIN);
-        #endif
+#else
+        SPI.begin(RADIO_SCLK_PIN, RADIO_MISO_PIN, RADIO_MOSI_PIN);
+#endif
         float freq = (float)Config.loramodule.rxFreq / 1000000;
         #if defined(RADIO_HAS_XTAL)
             radio.XTAL = true;

--- a/variants/ttgo-t8-esp32-s2-v1_1/board_pinout.h
+++ b/variants/ttgo-t8-esp32-s2-v1_1/board_pinout.h
@@ -1,0 +1,42 @@
+/* Copyright (C) 2025 Ricardo Guzman - CA2RXU
+ * 
+ * This file is part of LoRa APRS iGate.
+ * 
+ * LoRa APRS iGate is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or 
+ * (at your option) any later version.
+ * 
+ * LoRa APRS iGate is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with LoRa APRS iGate. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef BOARD_PINOUT_H_
+#define BOARD_PINOUT_H_
+
+    // Adds definitions for the now quite old TTGO T8 ESP32 S2 V1.1 board with a colour tft
+
+    //  LoRa Radio
+    #define HAS_SX1262
+    #define RADIO_SCLK_PIN          12
+    #define RADIO_MISO_PIN          13
+    #define RADIO_MOSI_PIN          11
+    #define RADIO_CS_PIN            2
+    #define RADIO_RST_PIN           6
+    #define RADIO_BUSY_PIN          1
+    #define RADIO_DIO1_PIN          7
+    #define RADIO_WAKEUP_PIN        RADIO_DIO1_PIN
+    #define GPIO_WAKEUP_PIN         GPIO_SEL_38
+
+    #define BATTERY_PIN             9
+
+    //  Display
+    #define HAS_DISPLAY
+    #define HAS_TFT
+
+#endif

--- a/variants/ttgo-t8-esp32-s2-v1_1/platformio.ini
+++ b/variants/ttgo-t8-esp32-s2-v1_1/platformio.ini
@@ -1,0 +1,43 @@
+[env:ttgo-t8-esp32-s2-v1_1]
+board = esp32-s2-saola-1
+board_build.embed_files = 
+	data_embed/index.html.gz
+	data_embed/style.css.gz
+	data_embed/script.js.gz
+	data_embed/bootstrap.css.gz
+	data_embed/bootstrap.js.gz
+	data_embed/favicon.png.gz
+build_flags =
+	${common.build_flags}
+	-D TTGO_T8_S2_DIY_LoRa
+	-D BOARD_HAS_PSRAM
+    -D USER_SETUP_LOADED
+    -D ST7789_DRIVER
+    -D CGRAM_OFFSET
+	-D TFT_WIDTH=135
+	-D TFT_HEIGHT=240
+    -D TFT_RGB_ORDER=TFT_BGR
+    -D TFT_INVERSION_ON
+    -D TFT_MISO=7
+    -D TFT_MOSI=35
+    -D TFT_SCLK=36
+    -D TFT_CS=34
+    -D TFT_DC=37
+    -D TFT_RST=38
+	-D TFT_BUSY=-1
+	-D TFT_BL=33
+	-D TFT_BACKLIGHT_ON=1
+    -D TOUCH_CS=-1
+    -D LOAD_GLCD
+    -D LOAD_FONT3
+    -D LOAD_FONT2
+    -D LOAD_FONT4
+    -D LOAD_FONT6
+    -D LOAD_FONT7
+    -D LOAD_FONT8
+    -D SPI_FREQUENCY=27000000
+    -D SPI_READ_FREQUENCY=16000000
+lib_deps =
+	${common.lib_deps}
+	${common.display_libs}
+    bodmer/TFT_eSPI @ 2.5.43    


### PR DESCRIPTION
I have added support for the TTGO T8 ESP32 S2 with TFT and an external SX1262 module (tested with a waveshare module)

The pcb repo can be found here: https://github.com/Xinyuan-LilyGO/LilyGo-T-Display-S2

I am not sure if you want to pull it into the main repo as it is quite an old board now, but if you do here are my changes. 

Thanks,
M7IYS