### PR TITLE
Check APRS-IS connection for backup Digi

### DIFF
--- a/src/wifi_utils.cpp
+++ b/src/wifi_utils.cpp
@@ -42,36 +42,21 @@ uint32_t    lastBackupDigiTime  = millis();
 namespace WIFI_Utils {
 
     void checkWiFi() {
-        if (Config.digi.ecoMode == 0) {
-            if (backUpDigiMode) {
-                uint32_t WiFiCheck = millis() - lastBackupDigiTime;
-                if (WiFi.status() != WL_CONNECTED && WiFiCheck >= 15 * 60 * 1000) {
-                    Serial.println("*** Stopping BackUp Digi Mode ***");
-                    backUpDigiMode = false;
-                    wifiCounter = 0;
-                } else if (WiFi.status() == WL_CONNECTED) {
-                    Serial.println("*** WiFi Reconnect Success (Stopping Backup Digi Mode) ***");
-                    backUpDigiMode = false;
-                    wifiCounter = 0;
-                }
-            }
+            if ((Config.digi.ecoMode == 0) && !backUpDigiMode && (WiFi.status() != WL_CONNECTED) && ((millis() - previousWiFiMillis) >= 30 * 1000) && !WiFiAutoAPStarted) {
+            Serial.print(millis());
+            Serial.println("Reconnecting to WiFi...");
+            WiFi.disconnect();
+            WIFI_Utils::startWiFi();//WiFi.reconnect();
+            previousWiFiMillis = millis();
 
-            if (!backUpDigiMode && (WiFi.status() != WL_CONNECTED) && ((millis() - previousWiFiMillis) >= 30 * 1000) && !WiFiAutoAPStarted) {
-                Serial.print(millis());
-                Serial.println("Reconnecting to WiFi...");
-                WiFi.disconnect();
-                WIFI_Utils::startWiFi();//WiFi.reconnect();
-                previousWiFiMillis = millis();
-
-                if (Config.backupDigiMode) {
-                    wifiCounter++;
-                }
-                if (wifiCounter >= 2) {
-                    Serial.println("*** Starting BackUp Digi Mode ***");
-                    backUpDigiMode = true;
-                    lastBackupDigiTime = millis();
-                }
+            if (Config.backupDigiMode) {
+                wifiCounter++;
             }
+            if (wifiCounter >= 2) {
+                Serial.println("*** Starting BackUp Digi Mode ***");
+                backUpDigiMode = true;
+                lastBackupDigiTime = millis();
+            }                    
         }
     }
 


### PR DESCRIPTION
I modified the logic to enable and disable Backup Digi Mode to also check the APRS-IS connectivity, not just the presence of Wifi. The new logic is as follows:

1. If Wifi is not available at boot or if it disconnects during operation - enable Backup Digi
2. If Wifi is available at boot or if it returns after a disconnect, we start checking APRS-IS.
3. Only when APRS-IS successfully connects - disable Backup Digi. Until APRS-IS is connected, we remain in Backup Digi even if Wifi is present.

All these operations react quickly - up to one minute. However:

4. If Wifi is available but APRS-IS suddenly disconnects (common scenario when the ISP has problems) - enable Backup Digi, but this takes almost 90 minutes.

I am not happy about this long delay, but the library has a fixed 5000 seconds (83 minutes) timeout for the connection to the APRS-IS server and we can only react on the timeout. Maybe a different version of the librarly will allow us to set a shorter timeout. But I would rather have  a 90 minute delay than forever staying on a Wifi without an uplink.

This requires more testing in different situations.

