### PR TITLE
incorrect value passed to radio.setBandwidth() in changeFreqTx() / changeFreqRx()

### DIFF
--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -105,7 +105,7 @@ namespace LoRa_Utils {
          
         radio.setSpreadingFactor(Config.loramodule.rxSpreadingFactor);
         radio.setCodingRate(Config.loramodule.rxCodingRate4);
-        float signalBandwidth = Config.loramodule.rxSignalBandwidth/1000;
+        float signalBandwidth = Config.loramodule.rxSignalBandwidth / 1000;
         radio.setBandwidth(signalBandwidth);        
         radio.setCRC(true);
 
@@ -156,7 +156,8 @@ namespace LoRa_Utils {
         radio.setFrequency(freq);
         radio.setSpreadingFactor(Config.loramodule.txSpreadingFactor);
         radio.setCodingRate(Config.loramodule.txCodingRate4);
-        radio.setBandwidth(Config.loramodule.txSignalBandwidth);
+        float signalBandwidth = Config.loramodule.txSignalBandwidth / 1000;
+        radio.setBandwidth(signalBandwidth);
     }
 
     void changeFreqRx() {
@@ -165,7 +166,8 @@ namespace LoRa_Utils {
         radio.setFrequency(freq);
         radio.setSpreadingFactor(Config.loramodule.rxSpreadingFactor);
         radio.setCodingRate(Config.loramodule.rxCodingRate4);
-        radio.setBandwidth(Config.loramodule.rxSignalBandwidth);
+        float signalBandwidth = Config.loramodule.rxSignalBandwidth / 1000;
+        radio.setBandwidth(signalBandwidth);
     }
 
     void sendNewPacket(const String& newPacket) {


### PR DESCRIPTION
when running "split" (different TX / RX frequencies), the calls to radio.setBandwidth() in changeFreqTx() and changeFreqRx() are passing the raw, scaled int value of bandwidth, direct from Config.  this will be rejected, with a return code of RADIOLIB_ERR_INVALID_BANDWIDTH.

changed these to match what's done in setup()