### PR TITLE
Added check if external i2c sensor already occupies address, skip during wx setup

### DIFF
--- a/include/battery_utils.h
+++ b/include/battery_utils.h
@@ -26,7 +26,7 @@ namespace BATTERY_Utils {
 
     void    adcCalibration();
     void    adcCalibrationCheck();
-    uint8_t externalI2CSensorActive();
+    uint8_t externalI2CSensorActiveAddr();
 
     void    setup();
     float   checkInternalVoltage();

--- a/src/battery_utils.cpp
+++ b/src/battery_utils.cpp
@@ -126,7 +126,7 @@ namespace BATTERY_Utils {
         return ina219.begin();
     }
 
-    uint8_t externalI2CSensorActive() {
+    uint8_t externalI2CSensorActiveAddr() {
         if ( externalI2CSensorType != 0 ) {
             return externalI2CSensorAddress;
         }

--- a/src/wx_utils.cpp
+++ b/src/wx_utils.cpp
@@ -61,11 +61,11 @@ namespace WX_Utils {
 
     void getWxModuleAddres() {
         uint8_t err, addr;
-        uint8_t extI2Caddr = BATTERY_Utils::externalI2CSensorActive();
+        uint8_t extI2Caddr = BATTERY_Utils::externalI2CSensorActiveAddr();
 
         for(addr = 1; addr < 0x7F; addr++) {
             if (addr == extI2Caddr) {
-                Serial.printf("0x%x occupied by I2C power sensor, skipping at Wx setup", addr);
+                Serial.printf("0x%x occupied by I2C power sensor, skipping for Wx setup\n", addr);
                 continue;
             }
             #ifdef SENSOR_I2C_BUS


### PR DESCRIPTION
I just switched over to an INA219 sensor for monitoring the external battery voltage on my iGate, but having the sensor on the bus made my BME280 unavailable.

The reason is the default 0x40 address for the INA219 overlapping with the expected address for the Si7021 sensor.

Blanking out the used address after initializing the INA219 fixes the issue for me.  