### PR TITLE
feat: add LILYGO T-Internet-PoE + OE5BPA LoRa HAT support

### DIFF
--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -295,81 +295,162 @@
                         </div>
                         <hr>
 
+                        <!-- Network -->
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
                                 <h5>
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        width="20"
-                                        height="20"
-                                        fill="currentColor"
-                                        class="bi bi-router-fill"
-                                        viewBox="0 0 16 16"
-                                    >
-                                        <path
-                                            d="M5.525 3.025a3.5 3.5 0 0 1 4.95 0 .5.5 0 1 0 .707-.707 4.5 4.5 0 0 0-6.364 0 .5.5 0 0 0 .707.707"
-                                        />
-                                        <path
-                                            d="M6.94 4.44a1.5 1.5 0 0 1 2.12 0 .5.5 0 0 0 .708-.708 2.5 2.5 0 0 0-3.536 0 .5.5 0 0 0 .707.707Z"
-                                        />
-                                        <path
-                                            d="M2.974 2.342a.5.5 0 1 0-.948.316L3.806 8H1.5A1.5 1.5 0 0 0 0 9.5v2A1.5 1.5 0 0 0 1.5 13H2a.5.5 0 0 0 .5.5h2A.5.5 0 0 0 5 13h6a.5.5 0 0 0 .5.5h2a.5.5 0 0 0 .5-.5h.5a1.5 1.5 0 0 0 1.5-1.5v-2A1.5 1.5 0 0 0 14.5 8h-2.306l1.78-5.342a.5.5 0 1 0-.948-.316L11.14 8H4.86zM2.5 11a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m4.5-.5a.5.5 0 1 1 1 0 .5.5 0 0 1-1 0m2.5.5a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m1.5-.5a.5.5 0 1 1 1 0 .5.5 0 0 1-1 0m2 0a.5.5 0 1 1 1 0 .5.5 0 0 1-1 0"
-                                        />
-                                        <path
-                                            d="M8.5 5.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0"
-                                        />
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-diagram-3-fill" viewBox="0 0 16 16">
+                                        <path fill-rule="evenodd" d="M6 3.5A1.5 1.5 0 0 1 7.5 2h1A1.5 1.5 0 0 1 10 3.5v1A1.5 1.5 0 0 1 8.5 6v1H14a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-1 0V8h-5v.5a.5.5 0 0 1-1 0V8h-5v.5a.5.5 0 0 1-1 0v-1A.5.5 0 0 1 2 7h5.5V6A1.5 1.5 0 0 1 6 4.5zm-6 8A1.5 1.5 0 0 1 1.5 10h1A1.5 1.5 0 0 1 4 11.5v1A1.5 1.5 0 0 1 2.5 14h-1A1.5 1.5 0 0 1 0 12.5zm6 0A1.5 1.5 0 0 1 7.5 10h1a1.5 1.5 0 0 1 1.5 1.5v1A1.5 1.5 0 0 1 8.5 14h-1A1.5 1.5 0 0 1 6 12.5zm6 0a1.5 1.5 0 0 1 1.5-1.5h1a1.5 1.5 0 0 1 1.5 1.5v1a1.5 1.5 0 0 1-1.5 1.5h-1a1.5 1.5 0 0 1-1.5-1.5z"/>
                                     </svg>
-                                    WiFi Access
+                                    Network
                                 </h5>
-                                <small
-                                    >Add all Wi-Fi Networks intended to be used.</small
-                                >
+                                <small>Configure WiFi, Ethernet, hostname and network services.</small>
                             </div>
                             <div class="col-lg-9 col-sm-12">
-                                <input
-                                    type="hidden"
-                                    name="wifi.APs"
-                                    id="wifi.APs"
-                                />
 
+                                <!-- Hostname + mDNS -->
+                                <div class="row mb-3 g-2">
+                                    <div class="col-md-6">
+                                        <label for="hostname" class="form-label">Hostname</label>
+                                        <input type="text" name="hostname" id="hostname" class="form-control" placeholder="iGATE-CALLSIGN (auto)" />
+                                        <div class="form-text">Used for DHCP and mDNS. Leave empty to use <code>iGATE-&lt;callsign&gt;</code>.</div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="form-check form-switch mt-4">
+                                            <input type="checkbox" name="mdns.enabled" id="mdns.enabled" class="form-check-input" />
+                                            <label for="mdns.enabled" class="form-label">Enable mDNS</label>
+                                            <div class="form-text">Reach the device as <code>hostname.local</code> on the local network (no DNS server needed).</div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <hr class="my-3">
+                                <h6 class="mb-3">WiFi</h6>
+
+                                <input type="hidden" name="wifi.APs" id="wifi.APs" />
                                 <div class="list-networks"></div>
-
-                                <div class="row new">
+                                <div class="row new mt-2 mb-3">
                                     <div class="d-grid gap-2">
-                                        <button
-                                            type="button"
-                                            class="btn btn-outline-primary"
-                                            data-toggle="collapse"
-                                            data-target="#add-ap"
-                                            aria-expanded="false"
-                                            aria-controls="add-ap"
-                                        >
+                                        <button type="button" class="btn btn-outline-primary" data-toggle="collapse" data-target="#add-ap" aria-expanded="false" aria-controls="add-ap">
                                             Add network
                                         </button>
                                     </div>
                                 </div>
-                                <div class="col-6 mt-3">
-                                    <label
-                                        for="startupDelay"
-                                        class="form-label"
-                                        >Startup Delay<small>(To Allow Router/Modem to start WiFiAP before connection)</small></label
-                                    >
-                                    <div class="input-group">
-                                        <input
-                                            type="number"
-                                            name="startupDelay"
-                                            id="startupDelay"
-                                            placeholder="0"
-                                            class="form-control"
-                                            step="1"
-                                            min="0"
-                                            max="5"
-                                        />
-                                        <span class="input-group-text"
-                                            >minutes</span
-                                        >
+                                <div id="lan-toggle-section" class="col-12 mb-3">
+                                    <div class="form-check form-switch">
+                                        <input type="checkbox" name="wifi.autoAP.disableOnLan" id="wifi.autoAP.disableOnLan" class="form-check-input" />
+                                        <label for="wifi.autoAP.disableOnLan" class="form-label">Disable WiFi when LAN cable is connected</label>
+                                        <div class="form-text">When enabled <strong>and</strong> a wired Ethernet link is detected at startup, WiFi is turned off completely. Toggle OFF to run WiFi and Ethernet simultaneously.</div>
                                     </div>
                                 </div>
+                                <hr class="my-2">
+                                <div class="col-6 mt-3">
+                                    <label for="startupDelay" class="form-label">Startup Delay<small> (Allow router/modem time to start before the device connects)</small></label>
+                                    <div class="input-group">
+                                        <input type="number" name="startupDelay" id="startupDelay" placeholder="0" class="form-control" step="1" min="0" max="5" />
+                                        <span class="input-group-text">minutes</span>
+                                    </div>
+                                </div>
+
+                                <hr class="my-3">
+                                <h6 class="mb-2">Auto Access Point (AP)</h6>
+                                <small class="d-block mb-2">A fallback WiFi AP will start if no network connection is available. Timeout counts from startup or last client disconnect.</small>
+                                <div class="col-12">
+                                    <div class="form-check form-switch">
+                                        <input type="checkbox" name="wifi.autoAP.enabled" id="wifi.autoAP.enabled" class="form-check-input" />
+                                        <label for="wifi.autoAP.enabled" class="form-label">Enable Auto AP</label>
+                                        <div class="form-text">Create Access Point (AP) when no network connection is available</div>
+                                    </div>
+                                </div>
+                                <div id="wifi-autoap-config" style="{{wifi.autoAP.enabled ? '' : 'display:none'}}">
+                                    <div class="row mt-3">
+                                        <div class="col-6">
+                                            <label for="wifi.autoAP.password" class="form-label">Password</label>
+                                            <div class="input-group">
+                                                <input type="password" name="wifi.autoAP.password" id="wifi.autoAP.password" class="form-control" placeholder="1234567890" required="" />
+                                            </div>
+                                        </div>
+                                        <div class="col-6">
+                                            <label for="wifi.autoAP.timeout" class="form-label">AP timeout (before searching again)</label>
+                                            <div class="input-group">
+                                                <input type="number" name="wifi.autoAP.timeout" id="wifi.autoAP.timeout" class="form-control" placeholder="10" required="" step="1" min="0" />
+                                                <span class="input-group-text">minutes</span>
+                                                <div class="form-text">Set to <strong>0</strong> if you don't want the AP to stop.</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <hr class="my-3">
+                                <h6 class="mb-2">WiFi Static IP <span id="wifi-mac-label" class="text-secondary fw-normal" style="font-size:0.8em;opacity:0.5"></span></h6>
+                                <small class="d-block mb-2">Fixed IP address for the WiFi interface. Leave disabled to use DHCP.</small>
+                                <div class="col-12">
+                                    <div class="form-check form-switch">
+                                        <input type="checkbox" name="wifi.staticIP.enabled" id="wifi.staticIP.enabled" class="form-check-input" />
+                                        <label for="wifi.staticIP.enabled" class="form-label">Enable WiFi Static IP</label>
+                                    </div>
+                                </div>
+                                <div id="wifi-static-ip-config" style="display:none">
+                                    <div class="row mt-3 g-2">
+                                        <div class="col-md-4">
+                                            <label for="wifi.staticIP.ip" class="form-label">IP Address</label>
+                                            <input type="text" name="wifi.staticIP.ip" id="wifi.staticIP.ip" class="form-control" placeholder="192.168.1.100" />
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label for="wifi.staticIP.gateway" class="form-label">Gateway</label>
+                                            <input type="text" name="wifi.staticIP.gateway" id="wifi.staticIP.gateway" class="form-control" placeholder="192.168.1.1" />
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label for="wifi.staticIP.subnet" class="form-label">Subnet Mask</label>
+                                            <input type="text" name="wifi.staticIP.subnet" id="wifi.staticIP.subnet" class="form-control" placeholder="255.255.255.0" />
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label for="wifi.staticIP.dns1" class="form-label">DNS 1</label>
+                                            <input type="text" name="wifi.staticIP.dns1" id="wifi.staticIP.dns1" class="form-control" placeholder="8.8.8.8" />
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label for="wifi.staticIP.dns2" class="form-label">DNS 2</label>
+                                            <input type="text" name="wifi.staticIP.dns2" id="wifi.staticIP.dns2" class="form-control" placeholder="8.8.4.4" />
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <hr class="my-3">
+                                <div id="lan-ethernet-section">
+                                <h6 class="mb-2">Ethernet Static IP <span id="ethernet-mac-label" class="text-secondary fw-normal" style="font-size:0.8em;opacity:0.5"></span></h6>
+                                <small class="d-block mb-2">Fixed IP address for the wired Ethernet interface (LAN8720). Only applies on boards with <code>HAS_ETHERNET</code>. Leave disabled to use DHCP.</small>
+                                <div class="col-12">
+                                    <div class="form-check form-switch">
+                                        <input type="checkbox" name="ethernet.staticIP.enabled" id="ethernet.staticIP.enabled" class="form-check-input" />
+                                        <label for="ethernet.staticIP.enabled" class="form-label">Enable Ethernet Static IP</label>
+                                    </div>
+                                </div>
+                                <div id="ethernet-static-ip-config" style="display:none">
+                                    <div class="row mt-3 g-2">
+                                        <div class="col-md-4">
+                                            <label for="ethernet.staticIP.ip" class="form-label">IP Address</label>
+                                            <input type="text" name="ethernet.staticIP.ip" id="ethernet.staticIP.ip" class="form-control" placeholder="192.168.1.100" />
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label for="ethernet.staticIP.gateway" class="form-label">Gateway</label>
+                                            <input type="text" name="ethernet.staticIP.gateway" id="ethernet.staticIP.gateway" class="form-control" placeholder="192.168.1.1" />
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label for="ethernet.staticIP.subnet" class="form-label">Subnet Mask</label>
+                                            <input type="text" name="ethernet.staticIP.subnet" id="ethernet.staticIP.subnet" class="form-control" placeholder="255.255.255.0" />
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label for="ethernet.staticIP.dns1" class="form-label">DNS 1</label>
+                                            <input type="text" name="ethernet.staticIP.dns1" id="ethernet.staticIP.dns1" class="form-control" placeholder="8.8.8.8" />
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label for="ethernet.staticIP.dns2" class="form-label">DNS 2</label>
+                                            <input type="text" name="ethernet.staticIP.dns2" id="ethernet.staticIP.dns2" class="form-control" placeholder="8.8.4.4" />
+                                        </div>
+                                    </div>
+                                </div>
+                                </div><!-- /lan-ethernet-section -->
+
                             </div>
                         </div>
                         <hr>
@@ -744,15 +825,15 @@
                                             name="digi.ecoMode"
                                             id="digi.ecoMode"
                                         >
-                                            <option value="0" selected>OFF (Normal Mode - WiFiAP and Serial Output enabled)</option>
-                                            <option value="1">Ultra Eco Mode (Sleep till Packet Rx (WiFiAP/WebUI & Display disabled))</option>
-                                            <option value="2">OFF (Normal Mode - WiFiAP disabled but Serial Output still enabled)</option>
+                                            <option value="0" selected>OFF (Normal Mode - AP and Serial Output enabled)</option>
+                                            <option value="1">Ultra Eco Mode (Sleep till Packet Rx (AP/WebUI &amp; Display disabled))</option>
+                                            <option value="2">OFF (Normal Mode - AP disabled, Serial Output still enabled)</option>
                                         </select>
                                     </div>                                    
                                     <div class="col-12 mt-3">
                                         <div class="form-check form-switch">
                                             <div class="form-text">
-                                                If WiFi/server connection is lost in iGate-only mode, the device switches to Digipeater mode (WIDE1-1) and retries connection every 15 minutes.
+                                                If the network/server connection is lost in iGate-only mode, the device switches to Digipeater mode (WIDE1-1) and retries every 15 minutes.
                                             </div>
                                             <input
                                                 type="checkbox"
@@ -1812,110 +1893,6 @@
                                             <span class="input-group-text"
                                                 >hours</span
                                             >
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <hr>
-
-                        <div class="row my-5 d-flex align-items-top">
-                            <div class="col-lg-3 col-sm-12">
-                                <h5>
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        width="20"
-                                        height="20"
-                                        fill="currentColor"
-                                        class="bi bi-router-fill"
-                                        viewBox="0 0 16 16"
-                                    >
-                                        <path
-                                            d="M5.525 3.025a3.5 3.5 0 0 1 4.95 0 .5.5 0 1 0 .707-.707 4.5 4.5 0 0 0-6.364 0 .5.5 0 0 0 .707.707"
-                                        />
-                                        <path
-                                            d="M6.94 4.44a1.5 1.5 0 0 1 2.12 0 .5.5 0 0 0 .708-.708 2.5 2.5 0 0 0-3.536 0 .5.5 0 0 0 .707.707Z"
-                                        />
-                                        <path
-                                            d="M2.974 2.342a.5.5 0 1 0-.948.316L3.806 8H1.5A1.5 1.5 0 0 0 0 9.5v2A1.5 1.5 0 0 0 1.5 13H2a.5.5 0 0 0 .5.5h2A.5.5 0 0 0 5 13h6a.5.5 0 0 0 .5.5h2a.5.5 0 0 0 .5-.5h.5a1.5 1.5 0 0 0 1.5-1.5v-2A1.5 1.5 0 0 0 14.5 8h-2.306l1.78-5.342a.5.5 0 1 0-.948-.316L11.14 8H4.86zM2.5 11a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m4.5-.5a.5.5 0 1 1 1 0 .5.5 0 0 1-1 0m2.5.5a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m1.5-.5a.5.5 0 1 1 1 0 .5.5 0 0 1-1 0m2 0a.5.5 0 1 1 1 0 .5.5 0 0 1-1 0"
-                                        />
-                                        <path
-                                            d="M8.5 5.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0"
-                                        />
-                                    </svg>
-                                    WiFi Auto AP
-                                </h5>
-                                <small
-                                    >WiFi AP will start if there is no WiFi
-                                    connection available. Timeout will count from 
-                                    startup or last client disconnected.</small
-                                >
-                            </div>
-                            <div class="col-9">
-                                <div class="row">
-                                    <div class="col-12">
-                                        <div class="form-check form-switch">
-                                            <input
-                                                type="checkbox"
-                                                name="wifi.autoAP.enabled"
-                                                id="wifi.autoAP.enabled"
-                                                class="form-check-input"
-                                            />
-                                            <label
-                                                for="wifi.autoAP.enabled"
-                                                class="form-label"
-                                                >Enable Auto AP</label
-                                            >
-                                            <div class="form-text">
-                                                Create WiFi AP when no network is available
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div id="wifi-autoap-config" style="{{wifi.autoAP.enabled ? '' : 'display:none'}}">
-                                    <div class="row mt-3">
-                                        <div class="col-6">
-                                            <label
-                                                for="wifi.autoAP.password"
-                                                class="form-label"
-                                                >Password</label
-                                            >
-                                            <div class="input-group">
-                                                <input
-                                                    type="password"
-                                                    name="wifi.autoAP.password"
-                                                    id="wifi.autoAP.password"
-                                                    class="form-control"
-                                                    placeholder="1234567890"
-                                                    required=""
-                                                />
-                                            </div>
-                                        </div>
-                                        <div class="col-6">
-                                            <label
-                                                for="wifi.autoAP.timeout"
-                                                class="form-label"
-                                                >WiFiAP timeout (to search again)</label
-                                            >
-                                            <div class="input-group">
-                                                <input
-                                                    type="number"
-                                                    name="wifi.autoAP.timeout"
-                                                    id="wifi.autoAP.timeout"
-                                                    class="form-control"
-                                                    placeholder="10"
-                                                    required=""
-                                                    step="1"
-                                                    min="0"
-                                                />
-                                                <span class="input-group-text"
-                                                    >minutes</span
-                                                >
-                                                <div class="form-text">
-                                                    Set to <strong>0</strong> if you don't
-                                                    want WiFi AP to stop.
-                                                </div>
-                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -55,6 +55,8 @@ function loadSettings(settings) {
     // General
     document.getElementById("callsign").value                           = settings.callsign;
     document.getElementById("tacticalCallsign").value                   = settings.tacticalCallsign;
+    document.getElementById("hostname").value                           = (settings.other && settings.other.hostname) ? settings.other.hostname : "";
+    document.getElementById("mdns.enabled").checked                    = (settings.other && settings.other.mdnsEnabled) ? settings.other.mdnsEnabled : false;
     document.getElementById("beacon.comment").value                     = settings.beacon.comment;
     document.getElementById("beacon.path").value                        = settings.beacon.path;
     document.getElementById("beacon.symbol").value                      = settings.beacon.symbol;
@@ -240,7 +242,28 @@ function loadSettings(settings) {
     document.getElementById("wifi.autoAP.enabled").checked              = settings.wifi.autoAP.enabled;
     document.getElementById("wifi.autoAP.password").value               = settings.wifi.autoAP.password;
     document.getElementById("wifi.autoAP.timeout").value                = settings.wifi.autoAP.timeout;
+    document.getElementById("wifi.autoAP.disableOnLan").checked         = settings.wifi.autoAP.disableOnLan || false;
     toggleWiFiAutoAPFields();
+
+    // WiFi Static IP
+    const wifiSIP = (settings.wifi && settings.wifi.staticIP) ? settings.wifi.staticIP : {};
+    document.getElementById("wifi.staticIP.enabled").checked            = wifiSIP.enabled  || false;
+    document.getElementById("wifi.staticIP.ip").value                   = wifiSIP.ip       || "";
+    document.getElementById("wifi.staticIP.gateway").value              = wifiSIP.gateway  || "";
+    document.getElementById("wifi.staticIP.subnet").value               = wifiSIP.subnet   || "255.255.255.0";
+    document.getElementById("wifi.staticIP.dns1").value                 = wifiSIP.dns1     || "8.8.8.8";
+    document.getElementById("wifi.staticIP.dns2").value                 = wifiSIP.dns2     || "8.8.4.4";
+    toggleStaticIPFields("wifi.staticIP.enabled", "wifi-static-ip-config");
+
+    // Ethernet Static IP
+    const ethSIP = (settings.ethernet && settings.ethernet.staticIP) ? settings.ethernet.staticIP : {};
+    document.getElementById("ethernet.staticIP.enabled").checked        = ethSIP.enabled   || false;
+    document.getElementById("ethernet.staticIP.ip").value               = ethSIP.ip        || "";
+    document.getElementById("ethernet.staticIP.gateway").value          = ethSIP.gateway   || "";
+    document.getElementById("ethernet.staticIP.subnet").value           = ethSIP.subnet    || "255.255.255.0";
+    document.getElementById("ethernet.staticIP.dns1").value             = ethSIP.dns1      || "8.8.8.8";
+    document.getElementById("ethernet.staticIP.dns2").value             = ethSIP.dns2      || "8.8.4.4";
+    toggleStaticIPFields("ethernet.staticIP.enabled", "ethernet-static-ip-config");
 
     // OTA
     document.getElementById("ota.username").value                       = settings.ota.username;
@@ -446,6 +469,19 @@ function toggleWiFiAutoAPFields() {
     if (autoAPConfig) autoAPConfig.style.display = isEnabled ? 'block' : 'none';
 }
 
+function toggleStaticIPFields(checkboxId, configDivId) {
+    const cb  = document.getElementById(checkboxId);
+    const div = document.getElementById(configDivId);
+    if (cb && div) div.style.display = cb.checked ? 'block' : 'none';
+}
+
+document.getElementById("wifi.staticIP.enabled").addEventListener("change", function() {
+    toggleStaticIPFields("wifi.staticIP.enabled", "wifi-static-ip-config");
+});
+document.getElementById("ethernet.staticIP.enabled").addEventListener("change", function() {
+    toggleStaticIPFields("ethernet.staticIP.enabled", "ethernet-static-ip-config");
+});
+
 
 document.querySelector(".new button").addEventListener("click", function () {
     const networksContainer = document.querySelector(".list-networks");
@@ -546,6 +582,27 @@ form.addEventListener("submit", async (event) => {
 });
 
 fetchSettings();
+
+fetch("/capabilities.json?t=" + Date.now())
+    .then(r => r.json())
+    .then(cap => {
+        if (cap.wifiMac) {
+            document.getElementById("wifi-mac-label").textContent = "(MAC: " + cap.wifiMac + ")";
+        }
+        if (cap.ethernetMac) {
+            document.getElementById("ethernet-mac-label").textContent = "(MAC: " + cap.ethernetMac + ")";
+        }
+        if (!cap.hasEthernet) {
+            ["lan-toggle-section", "lan-ethernet-section"].forEach(id => {
+                const el = document.getElementById(id);
+                if (el) {
+                    el.style.opacity = "0.35";
+                    el.style.pointerEvents = "none";
+                }
+            });
+        }
+    })
+    .catch(() => {});
 
 function loadReceivedPackets(packets) {
     if (packets) {

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -30,11 +30,22 @@ public:
     String  password;
 };
 
+class StaticIP {
+public:
+    bool    enabled;
+    String  ip;
+    String  gateway;
+    String  subnet;
+    String  dns1;
+    String  dns2;
+};
+
 class WiFi_Auto_AP {
 public:
     bool    enabled;            // Enable Auto AP
     String  password;
     int     timeout;
+    bool    disableOnLan;       // Disable WiFi STA when Ethernet is connected
 };
 
 class BEACON {
@@ -173,6 +184,8 @@ class Configuration {
 public:
     String                  callsign;
     String                  tacticalCallsign;
+    String                  hostname;
+    bool                    mdnsEnabled;
     int                     rememberStationTime;
     bool                    rebootMode;
     int                     rebootModeTime;
@@ -181,6 +194,8 @@ public:
     String                  blacklist;
     std::vector<WiFi_AP>    wifiAPs;
     WiFi_Auto_AP            wifiAutoAP;
+    StaticIP                wifiStaticIP;
+    StaticIP                ethernetStaticIP;
     BEACON                  beacon;
     APRS_IS                 aprs_is;
     DIGI                    digi;

--- a/include/network_manager.h
+++ b/include/network_manager.h
@@ -26,6 +26,13 @@ private:
     String _hostName = "";
     std::vector<WiFiNetwork> _wifiNetworks;
 
+    // WiFi static IP (empty = use DHCP)
+    String _wifiStaticIP      = "";
+    String _wifiStaticGW      = "";
+    String _wifiStaticSN      = "";
+    String _wifiStaticDNS1    = "";
+    String _wifiStaticDNS2    = "";
+
     int _findWiFiNetworkIndex(const String& ssid) const;
     bool _connectWiFi(const WiFiNetwork& network);
     void _processAPTimeout();
@@ -43,6 +50,9 @@ public:
     void loop();
 
     void setHostName(const String& hostName);
+    void setWiFiStaticIP(const String& ip, const String& gw, const String& sn,
+                         const String& dns1 = "", const String& dns2 = "");
+    void clearWiFiStaticIP();
 
     // WiFi methods
     bool setupAP(String apName, String apPsk = "");
@@ -76,6 +86,7 @@ public:
     // Check if specific network is connected
     bool isWiFiConnected() const;
     bool isEthernetConnected() const;
+    bool isEthernetEnabled() const;
     bool isModemConnected() const;
 
     bool isWifiAPActive() const;

--- a/src/LoRa_APRS_iGate.cpp
+++ b/src/LoRa_APRS_iGate.cpp
@@ -68,7 +68,7 @@ ___________________________________________________________________*/
 #endif
 
 
-String              versionDate             = "2026-03-25";
+String              versionDate             = "2026-04-02";
 String              versionNumber           = "3.2.3";
 Configuration       Config;
 WiFiClient          aprsIsClient;
@@ -106,7 +106,7 @@ void setup() {
     if (Config.wifiAutoAP.enabled) {
         networkManager->setAPTimeout(Config.wifiAutoAP.timeout * 60 * 1000); // Convert minutes to milliseconds
     }
-    networkManager->setHostName("iGATE-" + Config.callsign);
+    networkManager->setHostName(Config.hostname.isEmpty() ? ("iGATE-" + Config.callsign) : Config.hostname);
     POWER_Utils::setup();
     Utils::setupDisplay();
     LoRa_Utils::setup();

--- a/src/aprs_is_utils.cpp
+++ b/src/aprs_is_utils.cpp
@@ -95,6 +95,11 @@ namespace APRS_IS_Utils {
 
     void checkStatus() {
         String wifiState, aprsisState;
+        #ifdef HAS_ETHERNET
+        if (Config.wifiAutoAP.disableOnLan && networkManager->isEthernetConnected()) {
+            wifiState = "off";
+        } else
+        #endif
         if (networkManager->isWiFiConnected()) {
             wifiState = "OK";
         } else {

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -50,11 +50,29 @@ bool Configuration::writeFile() {
         data["wifi"]["autoAP"]["enabled"]           = wifiAutoAP.enabled;
         data["wifi"]["autoAP"]["password"]          = wifiAutoAP.password;
         data["wifi"]["autoAP"]["timeout"]           = wifiAutoAP.timeout;
+        data["wifi"]["autoAP"]["disableOnLan"]      = wifiAutoAP.disableOnLan;
+
+        data["wifi"]["staticIP"]["enabled"]         = wifiStaticIP.enabled;
+        data["wifi"]["staticIP"]["ip"]              = wifiStaticIP.ip;
+        data["wifi"]["staticIP"]["gateway"]         = wifiStaticIP.gateway;
+        data["wifi"]["staticIP"]["subnet"]          = wifiStaticIP.subnet;
+        data["wifi"]["staticIP"]["dns1"]            = wifiStaticIP.dns1;
+        data["wifi"]["staticIP"]["dns2"]            = wifiStaticIP.dns2;
+
+        data["ethernet"]["staticIP"]["enabled"]     = ethernetStaticIP.enabled;
+        data["ethernet"]["staticIP"]["ip"]          = ethernetStaticIP.ip;
+        data["ethernet"]["staticIP"]["gateway"]     = ethernetStaticIP.gateway;
+        data["ethernet"]["staticIP"]["subnet"]      = ethernetStaticIP.subnet;
+        data["ethernet"]["staticIP"]["dns1"]        = ethernetStaticIP.dns1;
+        data["ethernet"]["staticIP"]["dns2"]        = ethernetStaticIP.dns2;
 
         callsign.trim();
         data["callsign"]                            = callsign;
         tacticalCallsign.trim();
         data["tacticalCallsign"]                    = tacticalCallsign;
+        hostname.trim();
+        data["other"]["hostname"]                   = hostname;
+        data["other"]["mdnsEnabled"]                = mdnsEnabled;
 
         data["aprs_is"]["active"]                   = aprs_is.active;
         data["aprs_is"]["passcode"]                 = aprs_is.passcode;
@@ -223,11 +241,28 @@ bool Configuration::readFile() {
         wifiAutoAP.enabled              = data["wifi"]["autoAP"]["enabled"] | true;
         wifiAutoAP.password             = data["wifi"]["autoAP"]["password"] | "1234567890";
         wifiAutoAP.timeout              = data["wifi"]["autoAP"]["timeout"] | 10;
+        wifiAutoAP.disableOnLan         = data["wifi"]["autoAP"]["disableOnLan"] | false;
+
+        wifiStaticIP.enabled            = data["wifi"]["staticIP"]["enabled"] | false;
+        wifiStaticIP.ip                 = data["wifi"]["staticIP"]["ip"] | "";
+        wifiStaticIP.gateway            = data["wifi"]["staticIP"]["gateway"] | "";
+        wifiStaticIP.subnet             = data["wifi"]["staticIP"]["subnet"] | "255.255.255.0";
+        wifiStaticIP.dns1               = data["wifi"]["staticIP"]["dns1"] | "8.8.8.8";
+        wifiStaticIP.dns2               = data["wifi"]["staticIP"]["dns2"] | "8.8.4.4";
+
+        ethernetStaticIP.enabled        = data["ethernet"]["staticIP"]["enabled"] | false;
+        ethernetStaticIP.ip             = data["ethernet"]["staticIP"]["ip"] | "";
+        ethernetStaticIP.gateway        = data["ethernet"]["staticIP"]["gateway"] | "";
+        ethernetStaticIP.subnet         = data["ethernet"]["staticIP"]["subnet"] | "255.255.255.0";
+        ethernetStaticIP.dns1           = data["ethernet"]["staticIP"]["dns1"] | "8.8.8.8";
+        ethernetStaticIP.dns2           = data["ethernet"]["staticIP"]["dns2"] | "8.8.4.4";
 
         if (data["callsign"].isNull()) needsRewrite = true;
         callsign                        = data["callsign"] | "NOCALL-10";
         if (data["tacticalCallsign"].isNull()) needsRewrite = true;
         tacticalCallsign                = data["tacticalCallsign"] | "";
+        hostname                        = data["other"]["hostname"] | "";
+        mdnsEnabled                     = data["other"]["mdnsEnabled"] | false;
 
         if (data["aprs_is"]["active"].isNull() ||
             data["aprs_is"]["passcode"].isNull() ||
@@ -454,9 +489,26 @@ void Configuration::setDefaultValues() {
     wifiAutoAP.enabled              = true;
     wifiAutoAP.password             = "1234567890";
     wifiAutoAP.timeout              = 10;
+    wifiAutoAP.disableOnLan         = false;
+
+    wifiStaticIP.enabled            = false;
+    wifiStaticIP.ip                 = "";
+    wifiStaticIP.gateway            = "";
+    wifiStaticIP.subnet             = "255.255.255.0";
+    wifiStaticIP.dns1               = "8.8.8.8";
+    wifiStaticIP.dns2               = "8.8.4.4";
+
+    ethernetStaticIP.enabled        = false;
+    ethernetStaticIP.ip             = "";
+    ethernetStaticIP.gateway        = "";
+    ethernetStaticIP.subnet         = "255.255.255.0";
+    ethernetStaticIP.dns1           = "8.8.8.8";
+    ethernetStaticIP.dns2           = "8.8.4.4";
 
     callsign                        = "N0CALL-10";
     tacticalCallsign                = "";
+    hostname                        = "";
+    mdnsEnabled                     = false;
 
     aprs_is.active                  = false;
     aprs_is.passcode                = "XYZVW";

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include "esp_mac.h"
 
 #include "network_manager.h"
 
@@ -26,11 +27,27 @@ bool NetworkManager::_connectWiFi(const WiFiNetwork& network) {
 
     _wifiSTAmode = true;
 
+    // Hostname must be set before WiFi.mode() on Arduino Core 2.x for DHCP option 12
     if (!_hostName.isEmpty()) {
         WiFi.setHostname(_hostName.c_str());
+        Serial.println("[NM] WiFi hostname: " + _hostName);
     }
 
     WiFi.mode(_wifiAPmode ? WIFI_AP_STA : WIFI_STA);
+
+    if (!_wifiStaticIP.isEmpty()) {
+        // Static IP — must be applied after mode() and before begin()
+        IPAddress ip, gw, sn, d1, d2;
+        if (ip.fromString(_wifiStaticIP) && gw.fromString(_wifiStaticGW) && sn.fromString(_wifiStaticSN)) {
+            d1.fromString(_wifiStaticDNS1);
+            d2.fromString(_wifiStaticDNS2);
+            WiFi.config(ip, gw, sn, d1, d2);
+            Serial.println("[NM] WiFi static IP: " + _wifiStaticIP);
+        }
+    } else {
+        // DHCP — WiFi.config(INADDR_NONE) re-enables DHCP after mode change
+        WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+    }
 
     Serial.println("[NM] Attempting to connect to WiFi: " + network.ssid);
     WiFi.begin(network.ssid.c_str(), network.psk.c_str());
@@ -77,6 +94,12 @@ void NetworkManager::_processAPTimeout() {
 
 void NetworkManager::_onNetworkEvent(arduino_event_id_t event, arduino_event_info_t /*info*/) {
     switch (event) {
+        case ARDUINO_EVENT_WIFI_STA_START:
+            if (!_hostName.isEmpty()) {
+                Serial.println("[NM] WiFi STA Setting Hostname: " + _hostName);
+                WiFi.setHostname(_hostName.c_str());
+            }
+            break;
         case ARDUINO_EVENT_ETH_START:
             Serial.println("[NM] ETH Started");
             if (!_hostName.isEmpty()) {
@@ -124,6 +147,19 @@ void NetworkManager::loop() {
 
 void NetworkManager::setHostName(const String& hostName) {
     _hostName = hostName;
+}
+
+void NetworkManager::setWiFiStaticIP(const String& ip, const String& gw, const String& sn,
+                                      const String& dns1, const String& dns2) {
+    _wifiStaticIP   = ip;
+    _wifiStaticGW   = gw;
+    _wifiStaticSN   = sn;
+    _wifiStaticDNS1 = dns1;
+    _wifiStaticDNS2 = dns2;
+}
+
+void NetworkManager::clearWiFiStaticIP() {
+    _wifiStaticIP = "";
 }
 
 // WiFi methods
@@ -304,7 +340,16 @@ IPAddress NetworkManager::getEthernetIP() const {
 }
 
 String NetworkManager::getEthernetMACAddress() const {
-    return ETH.macAddress();
+    uint8_t mac[6];
+    esp_read_mac(mac, ESP_MAC_ETH);
+    char buf[18];
+    snprintf(buf, sizeof(buf), "%02X:%02X:%02X:%02X:%02X:%02X",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    return String(buf);
+}
+
+bool NetworkManager::isEthernetEnabled() const {
+    return _ethernetMode;
 }
 
 // Check if network is available

--- a/src/tnc_utils.cpp
+++ b/src/tnc_utils.cpp
@@ -50,17 +50,11 @@ namespace TNC_Utils {
         if (Config.tnc.enableServer && Config.digi.ecoMode == 0) {
             tncServer.stop();
             tncServer.begin();
-            String host = "igate-" + Config.callsign;
-            if (!MDNS.begin(host.c_str())) {
-                Serial.println("Error Starting mDNS");
-                tncServer.stop();
-                return;
+            Serial.println("TNC server started on port " + String(TNC_PORT));
+            if (Config.mdnsEnabled) {
+                MDNS.addService("kiss-tnc", "tcp", TNC_PORT);
+                Serial.println("[mDNS] _kiss-tnc._tcp announced on port " + String(TNC_PORT));
             }
-            if (!MDNS.addService("tnc", "tcp", TNC_PORT)) {
-                Serial.println("Error: Could not add mDNS service");
-            }
-            Serial.println("TNC server started successfully");
-            Serial.println("mDNS Host: " + host + ".local");
         }
     }
 

--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -17,7 +17,9 @@
  */
 
 #include <ArduinoJson.h>
+#include <ESPmDNS.h>
 #include "configuration.h"
+#include "network_manager.h"
 #include "ota_utils.h"
 #include "web_utils.h"
 #include "display.h"
@@ -25,6 +27,7 @@
 
 
 extern Configuration               Config;
+extern NetworkManager              *networkManager;
 extern uint32_t                    lastBeaconTx;
 extern std::vector<ReceivedPacket> receivedPackets;
 
@@ -97,6 +100,20 @@ namespace WEB_Utils {
         request->send(200, "application/json", fileContent);
     }
 
+    void handleCapabilities(AsyncWebServerRequest *request) {
+        JsonDocument data;
+        data["wifiMac"]     = networkManager->getWiFimacAddress();
+        data["hasEthernet"] = networkManager->isEthernetEnabled();
+        if (networkManager->isEthernetEnabled()) {
+            data["ethernetMac"] = networkManager->getEthernetMACAddress();
+        }
+        String buffer;
+        serializeJson(data, buffer);
+        AsyncWebServerResponse *response = request->beginResponse(200, "application/json", buffer);
+        response->addHeader("Cache-Control", "no-store");
+        request->send(response);
+    }
+
     void handleReceivedPackets(AsyncWebServerRequest *request) {
         JsonDocument data;
 
@@ -161,9 +178,30 @@ namespace WEB_Utils {
 
         Config.callsign                     = getParamStringSafe("callsign", Config.callsign);
         Config.tacticalCallsign             = getParamStringSafe("tacticalCallsign", Config.tacticalCallsign);
+        Config.hostname                     = getParamStringSafe("hostname", Config.hostname);
+        Config.mdnsEnabled                  = request->hasParam("mdns.enabled", true);
         Config.wifiAutoAP.enabled           = request->hasParam("wifi.autoAP.enabled", true);
         Config.wifiAutoAP.password          = getParamStringSafe("wifi.autoAP.password", Config.wifiAutoAP.password);
         Config.wifiAutoAP.timeout           = getParamIntSafe("wifi.autoAP.timeout", Config.wifiAutoAP.timeout);
+        Config.wifiAutoAP.disableOnLan      = request->hasParam("wifi.autoAP.disableOnLan", true);
+
+        Config.wifiStaticIP.enabled         = request->hasParam("wifi.staticIP.enabled", true);
+        if (Config.wifiStaticIP.enabled) {
+            Config.wifiStaticIP.ip          = getParamStringSafe("wifi.staticIP.ip",      Config.wifiStaticIP.ip);
+            Config.wifiStaticIP.gateway     = getParamStringSafe("wifi.staticIP.gateway", Config.wifiStaticIP.gateway);
+            Config.wifiStaticIP.subnet      = getParamStringSafe("wifi.staticIP.subnet",  Config.wifiStaticIP.subnet);
+            Config.wifiStaticIP.dns1        = getParamStringSafe("wifi.staticIP.dns1",    Config.wifiStaticIP.dns1);
+            Config.wifiStaticIP.dns2        = getParamStringSafe("wifi.staticIP.dns2",    Config.wifiStaticIP.dns2);
+        }
+
+        Config.ethernetStaticIP.enabled     = request->hasParam("ethernet.staticIP.enabled", true);
+        if (Config.ethernetStaticIP.enabled) {
+            Config.ethernetStaticIP.ip      = getParamStringSafe("ethernet.staticIP.ip",      Config.ethernetStaticIP.ip);
+            Config.ethernetStaticIP.gateway = getParamStringSafe("ethernet.staticIP.gateway", Config.ethernetStaticIP.gateway);
+            Config.ethernetStaticIP.subnet  = getParamStringSafe("ethernet.staticIP.subnet",  Config.ethernetStaticIP.subnet);
+            Config.ethernetStaticIP.dns1    = getParamStringSafe("ethernet.staticIP.dns1",    Config.ethernetStaticIP.dns1);
+            Config.ethernetStaticIP.dns2    = getParamStringSafe("ethernet.staticIP.dns2",    Config.ethernetStaticIP.dns2);
+        }
 
         Config.aprs_is.active               = request->hasParam("aprs_is.active", true);
         if (Config.aprs_is.active) {
@@ -360,6 +398,7 @@ namespace WEB_Utils {
         if (Config.digi.ecoMode == 0) {
             server.on("/", HTTP_GET, handleHome);
             server.on("/status", HTTP_GET, handleStatus);
+            server.on("/capabilities.json", HTTP_GET, handleCapabilities);
             server.on("/received-packets.json", HTTP_GET, handleReceivedPackets);
             server.on("/configuration.json", HTTP_GET, handleReadConfiguration);
             server.on("/configuration.json", HTTP_POST, handleWriteConfiguration);
@@ -375,6 +414,15 @@ namespace WEB_Utils {
             server.onNotFound(handleNotFound);
 
             server.begin();
+
+            if (Config.mdnsEnabled) {
+                String mdnsHost = Config.hostname.isEmpty() ? ("igate-" + Config.callsign) : Config.hostname;
+                mdnsHost.toLowerCase();
+                if (MDNS.begin(mdnsHost.c_str())) {
+                    MDNS.addService("http", "tcp", 80);
+                    Serial.println("[mDNS] Started: " + mdnsHost + ".local");
+                }
+            }
         }
     }
 

--- a/src/wifi_utils.cpp
+++ b/src/wifi_utils.cpp
@@ -40,7 +40,9 @@ namespace WIFI_Utils {
 
     void checkWiFi() {
         if (Config.digi.ecoMode != 0) return;
-
+        #ifdef HAS_ETHERNET
+            if (Config.wifiAutoAP.disableOnLan && networkManager->isEthernetConnected()) return;
+        #endif
         if (!networkManager->hasWiFiNetworks()) {
             return;
         }
@@ -103,6 +105,13 @@ namespace WIFI_Utils {
             return;
         }
 
+        if (Config.wifiStaticIP.enabled && !Config.wifiStaticIP.ip.isEmpty()) {
+            networkManager->setWiFiStaticIP(Config.wifiStaticIP.ip, Config.wifiStaticIP.gateway,
+                                             Config.wifiStaticIP.subnet, Config.wifiStaticIP.dns1,
+                                             Config.wifiStaticIP.dns2);
+        } else {
+            networkManager->clearWiFiStaticIP();
+        }
         displayShow("", "Connecting to WiFi:", "", "     loading ...", 0);
         networkManager->connectWiFi();
 
@@ -128,6 +137,32 @@ namespace WIFI_Utils {
     }
 
     void setup() {
+        #ifdef HAS_ETHERNET
+            // Init Ethernet first so we can decide whether to skip WiFi
+            displayShow("", " Starting Ethernet", "", "     loading ...", 0);
+            networkManager->ethernetConnect(ETH_PHY_LAN8720, ETHERNET_PHY_ADDR, ETHERNET_PHY_MDC, ETHERNET_PHY_MDIO, ETHERNET_PHY_NRST, ETH_CLOCK_GPIO17_OUT, true);
+            if (Config.ethernetStaticIP.enabled && !Config.ethernetStaticIP.ip.isEmpty()) {
+                networkManager->setEthernetIP(Config.ethernetStaticIP.ip, Config.ethernetStaticIP.gateway, Config.ethernetStaticIP.subnet, Config.ethernetStaticIP.dns1, Config.ethernetStaticIP.dns2);
+                Serial.println("[ETH] Static IP: " + Config.ethernetStaticIP.ip);
+            }
+            uint8_t ethAttempts = 0;
+            while (!networkManager->isEthernetConnected() && ethAttempts < 10) {
+                delay(500);
+                ethAttempts++;
+            }
+            if (networkManager->isEthernetConnected()) {
+                Serial.print("[ETH] Connected: ");
+                Serial.println(networkManager->getEthernetIP().toString());
+                displayShow("", "  Ethernet Ready!", "" , "     loading ...", 1000);
+                if (Config.wifiAutoAP.disableOnLan) {
+                    Serial.println("[WiFi] Disabled (LAN connected)");
+                    btStop();
+                    return;
+                }
+            } else {
+                Serial.println("[ETH] Link not established (WiFi fallback active)");
+            }
+        #endif
         if (Config.digi.ecoMode == 0) startWiFi();
         btStop();
     }

--- a/variants/lilygo-t-internet-poe-oe5bpa-lora-hat/board_pinout.h
+++ b/variants/lilygo-t-internet-poe-oe5bpa-lora-hat/board_pinout.h
@@ -1,0 +1,73 @@
+/* Copyright (C) 2025 Ricardo Guzman - CA2RXU
+ *
+ * This file is part of LoRa APRS iGate.
+ *
+ * LoRa APRS iGate is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LoRa APRS iGate is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LoRa APRS iGate. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// LILYGO T-Internet-PoE (ESP32-WROVER) + OE5BPA LoRa HAT (SX1278, SSD1306, 2 buttons)
+// Wired Ethernet via LAN8720 (PoE capable) as primary uplink; WiFi retained as fallback / WebConfig AP.
+// Env: lilygo-t-internet-poe-oe5bpa-lora-hat
+// Discussion: https://github.com/richonguzman/LoRa_APRS_iGate/discussions/235
+
+#ifndef BOARD_PINOUT_H_
+#define BOARD_PINOUT_H_
+
+    // LoRa Radio – SX1278 on OE5BPA HAT
+    // NOTE: GPIO12 is a boot-strapping pin (selects flash voltage).
+    //       The OE5BPA HAT ties CS through a series resistor so the line is
+    //       not driven HIGH during reset; verify the HAT has no hard pull-up on CS.
+    // NOTE: GPIO36 (SENSOR_VP) and GPIO39 (SENSOR_VN) are input-only;
+    //       they have no internal pull-up or pull-down.
+    #define HAS_SX1278
+    #define RADIO_SCLK_PIN          14
+    #define RADIO_MISO_PIN          2
+    #define RADIO_MOSI_PIN          15
+    #define RADIO_CS_PIN            12      // Strapping pin – see note above
+    #define RADIO_RST_PIN           4
+    #define RADIO_BUSY_PIN          36      // DIO0 on SX1278 (GPIO36/SENSOR_VP, input-only)
+    #define RADIO_WAKEUP_PIN        RADIO_BUSY_PIN
+    #define GPIO_WAKEUP_PIN         GPIO_SEL_36
+
+    // I2C – non-default pins, Wire.begin() handled in power_utils.cpp
+    #define USE_WIRE_WITH_OLED_PINS
+
+    // Display – SSD1306 OLED on OE5BPA HAT
+    #define HAS_DISPLAY
+
+    #undef  OLED_SDA
+    #undef  OLED_SCL
+    #undef  OLED_RST
+
+    #define OLED_SDA                33
+    #define OLED_SCL                32
+    #define OLED_RST                -1      // Reset pin # (or -1 if sharing Arduino reset pin)
+
+    // Buttons on OE5BPA HAT
+    // SW1 shares the boot-pin (GPIO0) which has an internal pull-up → active LOW.
+    // SW2 is on GPIO35 (input-only, no internal pull-up) → active HIGH (button pulls to VCC).
+    #define BUTTON_PIN              0       // SW1 – GPIO0 (boot pin, active LOW, internal pull-up)
+    #define BUTTON2_PIN             35      // SW2 – GPIO35 (input-only, active HIGH)
+
+    // Wired Ethernet – LAN8720 with PoE
+    // ETH_PHY_NRST (GPIO5) is passed as the power/reset pin to ETH.begin() so that
+    // the Arduino ETH library can cycle the PHY reset line during initialisation.
+    // ETH reference clock is output on GPIO17 (ETH_CLOCK_GPIO17_OUT, mode 3).
+    #define HAS_ETHERNET
+    #define ETHERNET_PHY_MDC        23
+    #define ETHERNET_PHY_MDIO       18
+    #define ETHERNET_PHY_NRST       5       // LAN8720 hardware reset (active-LOW, driven by ETH library)
+    #define ETHERNET_PHY_ADDR       0
+
+#endif

--- a/variants/lilygo-t-internet-poe-oe5bpa-lora-hat/platformio.ini
+++ b/variants/lilygo-t-internet-poe-oe5bpa-lora-hat/platformio.ini
@@ -1,0 +1,11 @@
+[env:lilygo-t-internet-poe-oe5bpa-lora-hat]
+board = esp32doit-devkit-v1
+build_flags =
+	${common.build_flags}
+	-D RADIOLIB_EXCLUDE_LR11X0=1
+	-D RADIOLIB_EXCLUDE_SX126X=1
+	-D RADIOLIB_EXCLUDE_SX128X=1
+	-D LILYGO_T_INTERNET_POE_OE5BPA_LORA_HAT
+lib_deps =
+	${common.lib_deps}
+	${common.display_libs}


### PR DESCRIPTION
## Summary

Adds full support for the **LILYGO T-Internet-PoE** board combined with the **OE5BPA LoRa HAT**. The board provides wired Ethernet (LAN8720 via PoE) alongside WiFi, and this PR wires everything together — static IP for both interfaces, reliable hostname delivery, optional mDNS, and a redesigned Network settings section in the web UI.

---

### NetworkManager improvements

- **WiFi static IP** is now stored inside `NetworkManager` (`setWiFiStaticIP` / `clearWiFiStaticIP`) so the config is no longer wiped by the internal reconnect logic
- **WiFi hostname** is applied in the `ARDUINO_EVENT_WIFI_STA_START` event handler — the only reliable point on Arduino Core 2.x to get the name into DHCP option 12
- **ETH hostname** is applied in the `ARDUINO_EVENT_ETH_START` event handler
- `isEthernetEnabled()` — runtime check whether Ethernet was initialised (avoids `#ifdef HAS_ETHERNET` spreading into unrelated files)
- `getEthernetMACAddress()` reads directly from the ESP32 eFuse via `esp_read_mac(ESP_MAC_ETH)` instead of relying on `ETH.macAddress()` which is unavailable before link-up

### Hostname & mDNS

- New config field **`hostname`** — custom device name; falls back to `iGATE-<callsign>` when left empty
- New config field **`mdnsEnabled`** — **off by default** (power users who need it know why to enable it)
- When enabled, `MDNS.begin()` is called in `WEB_Utils::setup()` and registers an HTTP service — device reachable as `hostname.local` over both WiFi and Ethernet, including when using a static IP (no DHCP required for name resolution)
- Hostname is sent in DHCP option 12 on both interfaces so it appears in router DNS tables

### Web UI — new Network section

All network-related settings previously scattered across the page are now consolidated into a single **Network** section:

| Sub-section | Contents |
|---|---|
| Identity | Hostname field, mDNS toggle (default off) |
| WiFi | Network list, Disable-WiFi-on-LAN toggle, Startup Delay, Auto AP |
| WiFi Static IP | Enable toggle + IP/GW/Mask/DNS fields; MAC address shown next to heading |
| Ethernet Static IP | Enable toggle + IP/GW/Mask/DNS fields; MAC address shown next to heading |

- MAC addresses are read directly from eFuse at runtime via `esp_read_mac()` — no guessing or derivation
- On boards **without** Ethernet (e.g. T-Beam, Heltec) the LAN-specific sections are automatically **grayed out** using the `hasEthernet` flag from `/capabilities.json`

### New variant

`variants/lilygo-t-internet-poe-oe5bpa-lora-hat/` — PlatformIO environment, board pinout (LAN8720 pins, `HAS_ETHERNET` define), and partition table.

---

## Tested by DO7TC / DM0IGH

- ✅ Static IP on LAN only
- ✅ Static IP on WiFi only
- ✅ Static IP on LAN + WiFi simultaneously
- ✅ DHCP fallback after disabling static IP on LAN
- ✅ DHCP fallback after disabling static IP on WiFi
- ✅ OTA firmware update over LAN
- ✅ OTA firmware update over WiFi
- ✅ DHCP hostname (option 12) verified with Wireshark on both interfaces
- ✅ mDNS verified with Wireshark
- ✅ _kiss-tnc._tcp DNS-SD announcement ([TCP-KISS-DNS-SD spec](https://github.com/hessu/aprs-specs/blob/master/TCP-KISS-DNS-SD.md))
- ✅ Hostname resolution on Windows 11 with `Resolve-DnsName`
- ✅ T-Beam v1.1 (no Ethernet): LAN sections correctly grayed out, no crashes