### PR TITLE
Add remote IO pin control via APRS messages

### DIFF
--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -2105,6 +2105,49 @@
                         <div class="row my-5 d-flex align-items-top">
                             <div class="col-lg-3 col-sm-12">
                                 <h5>
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-toggles" viewBox="0 0 16 16">
+                                        <path d="M4.5 9a3.5 3.5 0 1 0 0 7h7a3.5 3.5 0 1 0 0-7zm7 6a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5m-7-14a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5m2.45 0A3.49 3.49 0 0 1 8 3.5 3.49 3.49 0 0 1 6.95 6h4.55a2.5 2.5 0 0 0 0-5zM4.5 0h7a3.5 3.5 0 1 1 0 7h-7a3.5 3.5 0 1 1 0-7"/>
+                                    </svg>
+                                    IO Pin Control
+                                </h5>
+                                <small>Control GPIO pins via APRS messages.<br>Commands: <b>&lt;name&gt; ON</b>, <b>&lt;name&gt; OFF</b>, <b>&lt;name&gt; RESTART</b> (off for 15 sec, then on).<br>Set pin to -1 to disable.</small>
+                            </div>
+                            <div class="col-lg-9 col-sm-12">
+                                <div class="row fw-bold mb-1">
+                                    <div class="col-3"><small>GPIO pin no.</small></div>
+                                    <div class="col-9"><small>Name (used in APRS command)</small></div>
+                                </div>
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <input type="number" name="ioControl.pin0.pin" id="ioControl.pin0.pin" class="form-control form-control-sm" value="-1" min="-1" max="48" />
+                                    </div>
+                                    <div class="col-9">
+                                        <input type="text" name="ioControl.pin0.name" id="ioControl.pin0.name" class="form-control form-control-sm" placeholder="e.g. RELAY1" oninput="this.value = this.value.toUpperCase();" />
+                                    </div>
+                                </div>
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <input type="number" name="ioControl.pin1.pin" id="ioControl.pin1.pin" class="form-control form-control-sm" value="-1" min="-1" max="48" />
+                                    </div>
+                                    <div class="col-9">
+                                        <input type="text" name="ioControl.pin1.name" id="ioControl.pin1.name" class="form-control form-control-sm" placeholder="e.g. PUMP" oninput="this.value = this.value.toUpperCase();" />
+                                    </div>
+                                </div>
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <input type="number" name="ioControl.pin2.pin" id="ioControl.pin2.pin" class="form-control form-control-sm" value="-1" min="-1" max="48" />
+                                    </div>
+                                    <div class="col-9">
+                                        <input type="text" name="ioControl.pin2.name" id="ioControl.pin2.name" class="form-control form-control-sm" placeholder="e.g. LIGHT" oninput="this.value = this.value.toUpperCase();" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <hr>
+
+                        <div class="row my-5 d-flex align-items-top">
+                            <div class="col-lg-3 col-sm-12">
+                                <h5>
                                     <svg
                                         xmlns="http://www.w3.org/2000/svg"
                                         width="20"

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -258,6 +258,14 @@ function loadSettings(settings) {
     document.getElementById("remoteManagement.managers").value          = settings.remoteManagement.managers;
     document.getElementById("remoteManagement.rfOnly").checked          = settings.remoteManagement.rfOnly;
 
+    // IO Pin Control
+    if (settings.ioControl) {
+        for (let i = 0; i < 3; i++) {
+            document.getElementById("ioControl.pin" + i + ".pin").value  = settings.ioControl.pins[i].pin;
+            document.getElementById("ioControl.pin" + i + ".name").value = settings.ioControl.pins[i].name;
+        }
+    }
+
     // NTP
     document.getElementById("ntp.server").value                         = settings.ntp.server;
     document.getElementById("ntp.gmtCorrection").value                  = settings.ntp.gmtCorrection;

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -158,6 +158,18 @@ public:
     bool    rfOnly;
 };
 
+class IO_PIN {
+public:
+    int     pin;
+    String  name;
+    bool    state;
+};
+
+class IO_CONTROL {
+public:
+    IO_PIN  pins[3];
+};
+
 class MQTT {
 public:
     bool    active;
@@ -195,6 +207,7 @@ public:
     NTP                     ntp;
     REMOTE_MANAGEMENT       remoteManagement;
     MQTT                    mqtt;
+    IO_CONTROL              ioControl;
 
     void setup();
     void setDefaultValues();

--- a/include/query_utils.h
+++ b/include/query_utils.h
@@ -25,6 +25,8 @@
 namespace QUERY_Utils {
 
     String process(const String& query, const String& station, bool queryFromAPRSIS, bool thirdParty);
+    void   setupIoPins();
+    void   checkPendingPinRestarts();
 
 }
 

--- a/src/LoRa_APRS_iGate.cpp
+++ b/src/LoRa_APRS_iGate.cpp
@@ -62,6 +62,7 @@ ___________________________________________________________________*/
 #include "ntp_utils.h"
 #include "wx_utils.h"
 #include "display.h"
+#include "query_utils.h"
 #include "utils.h"
 #ifdef HAS_A7670
     #include "A7670_utils.h"
@@ -113,6 +114,7 @@ void setup() {
     Utils::validateFreqs();
     GPS_Utils::setup();
     STATION_Utils::loadBlacklistAndManagers();
+    QUERY_Utils::setupIoPins();
     Utils::startupDelay();
     SLEEP_Utils::setup();
     WIFI_Utils::setup();
@@ -222,6 +224,7 @@ void loop() {
             displayShow(firstLine, secondLine, thirdLine, fourthLine, fifthLine, sixthLine, seventhLine, 0);
         #endif
 
+        QUERY_Utils::checkPendingPinRestarts();
         Utils::checkRebootTime();
         Utils::checkSleepByLowBatteryVoltage(1);
     }

--- a/src/aprs_is_utils.cpp
+++ b/src/aprs_is_utils.cpp
@@ -186,18 +186,17 @@ namespace APRS_IS_Utils {
         } else {
             receivedMessage = packet.substring(colonIndex + 1);
         }
-        if (receivedMessage.indexOf("?") == 0) {
+        String queryResult = QUERY_Utils::process(receivedMessage, sender, false, thirdParty);
+        if (queryResult != "") {
             if (!Config.display.alwaysOn && Config.display.timeout != 0) {
                 displayToggle(true);
             }
-            STATION_Utils::addToOutputPacketBuffer(QUERY_Utils::process(receivedMessage, sender, false, thirdParty));
+            STATION_Utils::addToOutputPacketBuffer(queryResult);
             lastScreenOn = millis();
             displayShow(firstLine, secondLine, thirdLine, fourthLine, fifthLine, "Callsign = " + sender, "TYPE --> QUERY", 0);
             return true;
         }
-        else {
-            return false;
-        }
+        return false;
     }
 
     void processLoRaPacket(const String& packet) {
@@ -339,10 +338,9 @@ namespace APRS_IS_Utils {
                         } else {
                             receivedMessage = AddresseeAndMessage.substring(colonIndex + 1);
                         }
-                        if (receivedMessage.indexOf("?") == 0) {
+                        String queryAnswer = QUERY_Utils::process(receivedMessage, Sender, true, false);
+                        if (queryAnswer != "") {
                             Utils::println("Rx Query (APRS-IS)  : " + packet);
-                            String queryAnswer = QUERY_Utils::process(receivedMessage, Sender, true, false);
-                            //Serial.println("---> QUERY Answer : " + queryAnswer.substring(0,queryAnswer.indexOf("\n")));
                             if (!Config.display.alwaysOn && Config.display.timeout != 0) {
                                 displayToggle(true);
                             }

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -183,6 +183,12 @@ bool Configuration::writeFile() {
 
         data["other"]["rememberStationTime"]        = rememberStationTime;
 
+        for (int i = 0; i < 3; i++) {
+            data["ioControl"]["pins"][i]["pin"]     = ioControl.pins[i].pin;
+            data["ioControl"]["pins"][i]["name"]    = ioControl.pins[i].name;
+            data["ioControl"]["pins"][i]["state"]   = ioControl.pins[i].state;
+        }
+
         serializeJson(data, configFile);
         configFile.close();
         return true;
@@ -418,6 +424,13 @@ bool Configuration::readFile() {
         if (data["other"]["rememberStationTime"].isNull()) needsRewrite = true;
         rememberStationTime             = data["other"]["rememberStationTime"] | 30;
 
+        if (data["ioControl"]["pins"][0]["pin"].isNull()) needsRewrite = true;
+        for (int i = 0; i < 3; i++) {
+            ioControl.pins[i].pin       = data["ioControl"]["pins"][i]["pin"] | -1;
+            ioControl.pins[i].name      = data["ioControl"]["pins"][i]["name"] | "";
+            ioControl.pins[i].state     = data["ioControl"]["pins"][i]["state"] | false;
+        }
+
         if (wifiAPs.size() == 0) { // If we don't have any WiFi's from config we need to add "empty" SSID for AUTO AP
             WiFi_AP wifiap;
             wifiap.ssid = "";
@@ -561,6 +574,12 @@ void Configuration::setDefaultValues() {
     rebootModeTime                  = 0;
 
     rememberStationTime             = 30;
+
+    for (int i = 0; i < 3; i++) {
+        ioControl.pins[i].pin       = -1;
+        ioControl.pins[i].name      = "";
+        ioControl.pins[i].state     = false;
+    }
 
     Serial.println("New Data Created... All is Written!");
 }

--- a/src/query_utils.cpp
+++ b/src/query_utils.cpp
@@ -33,6 +33,8 @@ extern bool                             shouldSleepLowVoltage;
 extern bool                             saveNewDigiEcoModeConfig;
 extern String                           versionNumber;
 
+static uint32_t pendingPinRestart[3] = {0, 0, 0};
+
 
 namespace QUERY_Utils {
 
@@ -134,6 +136,32 @@ namespace QUERY_Utils {
             } else if (queryQuestion.startsWith("?COMMIT")) {     // saving for next reboot
                 answer = "New Config Saved";
                 Config.writeFile();
+            } else {
+                for (int i = 0; i < 3; i++) {
+                    if (Config.ioControl.pins[i].pin < 0 || Config.ioControl.pins[i].name == "") continue;
+                    String pinName = Config.ioControl.pins[i].name;
+                    pinName.toUpperCase();
+                    if (queryQuestion == pinName + " ON") {
+                        Config.ioControl.pins[i].state = true;
+                        Config.writeFile();
+                        digitalWrite(Config.ioControl.pins[i].pin, HIGH);
+                        answer = Config.ioControl.pins[i].name + ":ON";
+                        break;
+                    } else if (queryQuestion == pinName + " OFF") {
+                        Config.ioControl.pins[i].state = false;
+                        Config.writeFile();
+                        digitalWrite(Config.ioControl.pins[i].pin, LOW);
+                        answer = Config.ioControl.pins[i].name + ":OFF";
+                        break;
+                    } else if (queryQuestion == pinName + " RESTART") {
+                        Config.ioControl.pins[i].state = true;
+                        Config.writeFile();
+                        digitalWrite(Config.ioControl.pins[i].pin, LOW);
+                        pendingPinRestart[i] = millis();
+                        answer = Config.ioControl.pins[i].name + ":RESTART(15s)";
+                        break;
+                    }
+                }
             }
         }
 
@@ -165,6 +193,26 @@ namespace QUERY_Utils {
         queryAnswer += char(random(97, 123));
         queryAnswer += "*";
         return queryAnswer;
+    }
+
+    void setupIoPins() {
+        for (int i = 0; i < 3; i++) {
+            if (Config.ioControl.pins[i].pin >= 0) {
+                pinMode(Config.ioControl.pins[i].pin, OUTPUT);
+                digitalWrite(Config.ioControl.pins[i].pin, Config.ioControl.pins[i].state ? HIGH : LOW);
+            }
+        }
+    }
+
+    void checkPendingPinRestarts() {
+        for (int i = 0; i < 3; i++) {
+            if (pendingPinRestart[i] > 0 && millis() - pendingPinRestart[i] >= 15000) {
+                if (Config.ioControl.pins[i].pin >= 0) {
+                    digitalWrite(Config.ioControl.pins[i].pin, HIGH);
+                }
+                pendingPinRestart[i] = 0;
+            }
+        }
     }
 
 }

--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -292,6 +292,11 @@ namespace WEB_Utils {
 
         Config.rememberStationTime          = getParamIntSafe("other.rememberStationTime", Config.rememberStationTime);
 
+        for (int i = 0; i < 3; i++) {
+            Config.ioControl.pins[i].pin    = getParamIntSafe("ioControl.pin" + String(i) + ".pin",  Config.ioControl.pins[i].pin);
+            Config.ioControl.pins[i].name   = getParamStringSafe("ioControl.pin" + String(i) + ".name", Config.ioControl.pins[i].name);
+        }
+
         bool saveSuccess = Config.writeFile();
 
         if (saveSuccess) {


### PR DESCRIPTION
Allows up to 3 GPIO pins to be toggled ON/OFF or power-cycled (RESTART) by sending APRS messages from authorized manager callsigns. Pin numbers and names are configurable via the web interface. Pin state is persisted across reboots. RESTART turns the pin off for 15 seconds then back on.