### PR TITLE
Mic-E Syslog fixes

### DIFF
--- a/src/gps_utils.cpp
+++ b/src/gps_utils.cpp
@@ -150,13 +150,72 @@ namespace GPS_Utils {
         return buildDistanceAndComment(convertedLatitude, convertedLongitude, infoGPS.substring(19));
     }
 
+// ---------------------------------------------------------------------------
+// Decode a Mic-E packet's position, return "lat / lon / dist" (km).
+// Algorithm verified against a reference APRS decoder (matched to 6
+// decimal places on a real captured packet). Ambiguity chars (K/L/Z)
+// bail out safely rather than emit a wrong fix.
+// Units are KM to match the GPS path (dashboard already converts km->mi).
+// ---------------------------------------------------------------------------
+static int miceDestDigit(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'A' && c <= 'J') return c - 'A';   // custom-message chars
+    if (c >= 'P' && c <= 'Y') return c - 'P';   // standard-message chars
+    return -1;                                  // K/L/Z = position ambiguity
+}
+
+String decodeMicEGPS(const String& packet) {
+    int gt    = packet.indexOf('>');
+    int comma = packet.indexOf(',');
+    int colon = packet.indexOf(':');
+    if (gt < 0 || colon < 0) return " _ / _ / _ ";
+
+    // AX.25 destination = between '>' and first ',' (path) or ':' if no path
+    int destEnd = (comma > gt && comma < colon) ? comma : colon;
+    String dest = packet.substring(gt + 1, destEnd);
+    if (dest.length() < 6) return " _ / _ / _ ";
+
+    // Info must start with Mic-E data-type indicator '`' or '\'' ,
+    // then 3 longitude bytes follow it
+    char dti = packet[colon + 1];
+    if ((dti != '`' && dti != '\'') || colon + 4 >= (int)packet.length())
+        return " _ / _ / _ ";
+
+    // latitude from destination: DD MM.hh
+    int d[6];
+    for (int i = 0; i < 6; i++) {
+        d[i] = miceDestDigit(dest[i]);
+        if (d[i] < 0) return " _ / _ / _ ";     // ambiguity -> don't guess
+    }
+    float latitude = (d[0]*10 + d[1]) + ((d[2]*10 + d[3]) + (d[4]*10 + d[5])/100.0)/60.0;
+    if (dest[3] >= '0' && dest[3] <= '9') latitude = -latitude;   // dest[3] 0-9 => South
+
+    int  lonOffset = (dest[4] >= 'P' && dest[4] <= 'Z') ? 100 : 0; // dest[4] P-Z => +100
+    bool west      = (dest[5] >= 'P' && dest[5] <= 'Z');           // dest[5] P-Z => West
+
+    // longitude from the 3 info bytes after the indicator
+    int lonDeg = (packet[colon+2] - 28) + lonOffset;
+    if      (lonDeg >= 180 && lonDeg <= 189) lonDeg -= 80;
+    else if (lonDeg >= 190 && lonDeg <= 199) lonDeg -= 190;
+    int lonMin = packet[colon+3] - 28;  if (lonMin >= 60) lonMin -= 60;
+    int lonHh  = packet[colon+4] - 28;
+    float longitude = lonDeg + (lonMin + lonHh/100.0)/60.0;
+    if (west) longitude = -longitude;
+
+
+    // NEW: same lat/lon/distance builder as the GPS path; no comment field
+    // (Mic-E payload is intentionally dropped - location + signal only)
+    return buildDistanceAndComment(latitude, longitude, "");
+}
+
     String getDistanceAndComment(const String& packet) {
         int indexOfAt = packet.indexOf(":@");
         if (indexOfAt > 10) return getReceivedGPS(packet);
 
-        const uint8_t nonEncondedLatitudeOffset     = 9;    // "N" / "S"
-        const uint8_t nonEncondedLongitudeOffset    = 19;   // "E" / "W"
-        const uint8_t encodedByteOffset             = 14;
+        // Mic-E (data-type indicator ':`' or ":'") -> decode it ourselves
+        int indexOfMicE = packet.indexOf(":`");
+        if (indexOfMicE < 0) indexOfMicE = packet.indexOf(":'");
+        if (indexOfMicE > 10) return decodeMicEGPS(packet);
 
         int indexOfExclamation  = packet.indexOf(":!");
         int indexOfEqual        = packet.indexOf(":=");
@@ -168,20 +227,20 @@ namespace GPS_Utils {
         }
         if (baseIndex == -1) return " _ / _ / _ ";
 
-        int latitudeIndex       = baseIndex + nonEncondedLatitudeOffset;
-        int longitudeIndex      = baseIndex + nonEncondedLongitudeOffset;
-        int encodedByteIndex    = baseIndex + encodedByteOffset;
         int packetLength        = packet.length();
 
-        if (latitudeIndex < packetLength && longitudeIndex < packetLength) {
-            char latChar = packet[latitudeIndex];
-            char lngChar = packet[longitudeIndex];
-            if ((latChar == 'N' || latChar == 'S') && (lngChar == 'E' || lngChar == 'W')) return getReceivedGPS(packet);
-        }
-        if (encodedByteIndex < packetLength) {
-            char byteChar = packet[encodedByteIndex];
-            if (byteChar == 'G' || byteChar == 'Q' || byteChar == '[' || byteChar == 'H' || byteChar == 'X' || byteChar == '3') return decodeEncodedGPS(packet);
-        }
+        // Spec-based branch on the FIRST info character after the DTI.
+        // APRS spec: an uncompressed position always starts with a latitude
+        // digit; a compressed (base-91) position always starts with the
+        // symbol table char: '/', '\\', or an overlay 'A'-'Z' / 'a'-'j'.
+        // This accepts every conformant encoder, independent of a fixed
+        // whitelist of compression-type bytes.
+        if (baseIndex + 2 >= packetLength) return " _ / _ / _ ";
+        char firstInfoChar = packet[baseIndex + 2];
+        if (firstInfoChar >= '0' && firstInfoChar <= '9') return getReceivedGPS(packet);
+        if (firstInfoChar == '/' || firstInfoChar == '\\' ||
+            (firstInfoChar >= 'A' && firstInfoChar <= 'Z') ||
+            (firstInfoChar >= 'a' && firstInfoChar <= 'j')) return decodeEncodedGPS(packet);
         return " _ / _ / _ ";
     }
 

--- a/src/lora_utils.cpp
+++ b/src/lora_utils.cpp
@@ -65,6 +65,22 @@ float snr;
 
 namespace LoRa_Utils {
 
+    // Sanitizer for the WebUI copy of a received packet. Mic-E payloads
+    // legitimately contain control bytes (e.g. 0x1C encoding low speed); raw
+    // control characters are invalid inside JSON strings (RFC 8259) and can
+    // break JSON.parse on the Received Packets page. Replaces 0x00-0x1F and
+    // 0x7F with '.' (hexdump convention). Comparison is on the UNSIGNED byte
+    // so UTF-8 comment bytes (>= 0x80, spec-legal) pass through untouched.
+    // Display copy only - syslog / APRS-IS / digi all use the original packet.
+    static String sanitizeForWeb(const String& s) {
+        String out = s;
+        for (int i = 0; i < (int)out.length(); i++) {
+            uint8_t c = (uint8_t)out[i];
+            if (c < 32 || c == 127) out.setCharAt(i, '.');
+        }
+        return out;
+    }
+
     void setFlag(void) {
         operationDone = true;
     }
@@ -238,7 +254,7 @@ namespace LoRa_Utils {
                                 }
                                 ReceivedPacket receivedPacket;
                                 receivedPacket.rxTime   = NTP_Utils::getFormatedTime();
-                                receivedPacket.packet   = packet.substring(3);
+                                receivedPacket.packet   = sanitizeForWeb(packet.substring(3));
                                 receivedPacket.RSSI     = rssi;
                                 receivedPacket.SNR      = snr;
                                 receivedPackets.push_back(receivedPacket);

--- a/src/syslog_utils.cpp
+++ b/src/syslog_utils.cpp
@@ -79,11 +79,15 @@ namespace SYSLOG_Utils {
                         syslogPacket.concat(sender);
                         syslogPacket.concat(" ---> ");
                         syslogPacket.concat(packet.substring(colonIndex + 2));
-                    } else if (nextChar == '`') {
+                    } else if (nextChar == '`' || nextChar == '\'') {     // both Mic-E DTIs are valid
                         syslogPacket.concat("MIC-E / ");
                         syslogPacket.concat(sender);
                         syslogPacket.concat(" ---> ");
+                        syslogPacket.concat(String(nextChar));  // restore the actual indicator received
                         syslogPacket.concat(packet.substring(colonIndex + 2));
+                        // append distance for Mic-E, same as the GPS path
+                        syslogPacket.concat(" / ");
+                        syslogPacket.concat(GPS_Utils::getDistanceAndComment(packet));
                     } else if (nextChar == ';') {
                         syslogPacket.concat("OBJECT / ");
                         syslogPacket.concat(sender);


### PR DESCRIPTION
## 1. Older Mic-E packets are mislabeled, and the type byte is lost (bug)

Mic-E packets can start with either of two type characters: the current
backtick (`` ` ``) or the older apostrophe (`'`). The firmware only recognizes
the backtick, so packets from older trackers using the apostrophe get sorted
into the wrong category.

Also, when the packet is written out to syslog, that leading type character is
dropped. Without it, the Mic-E data can't be decoded by anything reading the
syslog — I confirmed this with a standard APRS decoder: it fails on the line
as sent, and works once the character is put back.

**Fix:** recognize both type characters, and keep the original one in the
syslog output.

## 2. Some compressed-position packets aren't recognized (bug)

The firmware decides whether a packet uses compressed positions by checking
its "type" byte against a short fixed list of values. That list doesn't cover
everything the APRS spec allows, so some valid compressed packets are missed
and show no distance.

**Fix:** detect compressed packets the way the spec defines them, instead of
matching against the fixed list.

## 3. Certain Mic-E packets break the "Received Packets" web page (bug)

Mic-E packets can legitimately contain non-printable bytes (for example, one
byte value is used to encode low speeds). When such a packet is shown on the
WebUI's Received Packets page, those bytes end up inside the page's data and
break it — the packet list stops displaying.

**Fix:** for the web display copy only, replace non-printable bytes with a
dot (like a hex viewer does). The real packet is untouched — syslog, APRS-IS,
and digipeating all still use the original bytes.

## 4. Mic-E packets get position and distance in syslog (improvement)

For normal position beacons, the syslog line includes latitude, longitude, and
distance from the iGate — great for coverage/range monitoring. For Mic-E
packets it shows blanks instead, even though the firmware has already decoded
the position internally (it forwards it to APRS-IS just fine). The decoded
position just never makes it into the syslog line.

**Fix:** decode the Mic-E position and include lat / lon / distance in the
syslog line, in the same format the normal beacons already use. I checked the
decoded coordinates against an independent APRS decoder and they match.