### PR TITLE
Enable Tactical Callsigns

### DIFF
--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -1827,6 +1827,46 @@
                                         width="20"
                                         height="20"
                                         fill="currentColor"
+                                        class="bi bi-signpost-fill"
+                                        viewBox="0 0 16 16"
+                                    >
+                                        <path
+                                            d="M7 1.414V4H2a1 1 0 0 0-.8.4L.4 5.2a1 1 0 0 0 0 1.6l.8 1.2A1 1 0 0 0 2 8h5v6.5a.5.5 0 0 0 1 0V8h5a1 1 0 0 0 .8-.4l.8-1.2a1 1 0 0 0 0-1.6l-.8-1.2A1 1 0 0 0 13 4H8V1.414a1 1 0 0 0-.293-.707L7.5.5l-.207.207A1 1 0 0 0 7 1.414"
+                                        />
+                                    </svg>
+                                    Callsign Validation
+                                </h5>
+                            </div>
+                            <div class="col-9">
+                                <div class="row">
+                                    <div class="col-12">
+                                        <div class="form-check form-switch">
+                                            <input
+                                                type="checkbox"
+                                                name="other.allowAnyCallsign"
+                                                id="other.allowAnyCallsign"
+                                                class="form-check-input"
+                                            />
+                                            <label
+                                                for="other.allowAnyCallsign"
+                                                class="form-label"
+                                                >Allow Any Callsign (skip strict amateur-radio format check, 3-9 characters)</label
+                                            >
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <hr>
+
+                        <div class="row my-5 d-flex align-items-top">
+                            <div class="col-lg-3 col-sm-12">
+                                <h5>
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        width="20"
+                                        height="20"
+                                        fill="currentColor"
                                         class="bi bi-router-fill"
                                         viewBox="0 0 16 16"
                                     >

--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -1834,7 +1834,7 @@
                                             d="M7 1.414V4H2a1 1 0 0 0-.8.4L.4 5.2a1 1 0 0 0 0 1.6l.8 1.2A1 1 0 0 0 2 8h5v6.5a.5.5 0 0 0 1 0V8h5a1 1 0 0 0 .8-.4l.8-1.2a1 1 0 0 0 0-1.6l-.8-1.2A1 1 0 0 0 13 4H8V1.414a1 1 0 0 0-.293-.707L7.5.5l-.207.207A1 1 0 0 0 7 1.414"
                                         />
                                     </svg>
-                                    Callsign Validation
+                                    Tactical Callsign
                                 </h5>
                             </div>
                             <div class="col-9">
@@ -1850,7 +1850,7 @@
                                             <label
                                                 for="other.allowAnyCallsign"
                                                 class="form-label"
-                                                >Allow Any Callsign (skip strict amateur-radio format check, 3-9 characters)</label
+                                                >Allow Tactical Callsigns to APRS Network (skip strict amateur-radio format check, 3-9 characters allowed)</label
                                             >
                                         </div>
                                     </div>

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -236,6 +236,8 @@ function loadSettings(settings) {
     RebootModeCheckbox.checked  = settings.other.rebootMode;
     RebootModeTime.disabled     = !RebootModeCheckbox.check;
 
+    document.getElementById("other.allowAnyCallsign").checked           = settings.other.allowAnyCallsign;
+
     // WiFi Auto AP
     document.getElementById("wifi.autoAP.enabled").checked              = settings.wifi.autoAP.enabled;
     document.getElementById("wifi.autoAP.password").value               = settings.wifi.autoAP.password;

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -176,6 +176,7 @@ public:
     int                     rememberStationTime;
     bool                    rebootMode;
     int                     rebootModeTime;
+    bool                    allowAnyCallsign;
     int                     startupDelay;
     String                  personalNote;
     String                  blacklist;

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -182,6 +182,7 @@ bool Configuration::writeFile() {
         data["other"]["rebootModeTime"]             = rebootModeTime;
 
         data["other"]["rememberStationTime"]        = rememberStationTime;
+        data["other"]["allowAnyCallsign"]           = allowAnyCallsign;
 
         serializeJson(data, configFile);
         configFile.close();
@@ -418,6 +419,9 @@ bool Configuration::readFile() {
         if (data["other"]["rememberStationTime"].isNull()) needsRewrite = true;
         rememberStationTime             = data["other"]["rememberStationTime"] | 30;
 
+        if (data["other"]["allowAnyCallsign"].isNull()) needsRewrite = true;
+        allowAnyCallsign                = data["other"]["allowAnyCallsign"] | false;
+
         if (wifiAPs.size() == 0) { // If we don't have any WiFi's from config we need to add "empty" SSID for AUTO AP
             WiFi_AP wifiap;
             wifiap.ssid = "";
@@ -561,6 +565,7 @@ void Configuration::setDefaultValues() {
     rebootModeTime                  = 0;
 
     rememberStationTime             = 30;
+    allowAnyCallsign                = false;
 
     Serial.println("New Data Created... All is Written!");
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -432,6 +432,7 @@ namespace Utils {
     bool callsignIsValid(const String& callsign) {
         if (callsign == "WLNK-1") return true;
         int totalCallsignLength = callsign.length();
+        if (Config.allowAnyCallsign) return totalCallsignLength >= 3 && totalCallsignLength <= 9;
         if (totalCallsignLength < 4) return false;
 
         int hyphenIndex         = callsign.indexOf("-");

--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -291,6 +291,7 @@ namespace WEB_Utils {
         Config.ntp.gmtCorrection            = getParamFloatSafe("ntp.gmtCorrection", Config.ntp.gmtCorrection);
 
         Config.rememberStationTime          = getParamIntSafe("other.rememberStationTime", Config.rememberStationTime);
+        Config.allowAnyCallsign             = request->hasParam("other.allowAnyCallsign", true);
 
         bool saveSuccess = Config.writeFile();
 


### PR DESCRIPTION
Add option to allow any callsign format, skipping strict amateur-radio validation and allowing tactical callsigns

This is a setting on the config page so that not everyone has to allow it on their gateways.
<img width="803" height="159" alt="Screenshot 2026-08-07 at 9 06 23 PM" src="https://github.com/user-attachments/assets/a735e97b-09c1-414b-8caa-420f6643d68e" />
