### PR TITLE
feat: add per-gateway opt-in for tactical callsign acceptance

### DIFF
--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -858,7 +858,7 @@ body{background:var(--msh-bg);color:var(--msh-text);font-family:"Inter",system-u
                             </div>
                             <div class="col-lg-9 col-sm-12">
                                 <div class="row">
-                                    <div class="col-12">
+                                    <div class="col-6">
                                         <div class="form-check form-switch">
                                             <input
                                                 type="checkbox"
@@ -871,6 +871,22 @@ body{background:var(--msh-bg);color:var(--msh-text);font-family:"Inter",system-u
                                                 class="form-label"
                                                 >Enable APRS-IS
                                                 connection</label
+                                            >
+                                        </div>
+                                    </div>
+                                    <div class="col-6">
+                                        <div class="form-check form-switch">
+                                            <input
+                                                type="checkbox"
+                                                name="other.allowAnyCallsign"
+                                                id="other.allowAnyCallsign"
+                                                class="form-check-input"
+                                            />
+                                            <label
+                                                for="other.allowAnyCallsign"
+                                                class="form-label"
+                                                >Gate Tactical Callsigns to
+                                                APRS-IS</label
                                             >
                                         </div>
                                     </div>

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -250,6 +250,8 @@ function loadSettings(settings) {
     RebootModeCheckbox.checked  = settings.other.rebootMode;
     RebootModeTime.disabled     = !RebootModeCheckbox.check;
 
+    document.getElementById("other.allowAnyCallsign").checked           = settings.other.allowAnyCallsign;
+
     // WiFi Auto AP
     document.getElementById("wifi.autoAP.enabled").checked              = settings.wifi.autoAP.enabled;
     document.getElementById("wifi.autoAP.password").value               = settings.wifi.autoAP.password;

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -100,6 +100,7 @@ function loadSettings(settings) {
 
     // APRS-IS
     document.getElementById("aprs_is.active").checked                   = settings.aprs_is.active;
+    document.getElementById("other.allowAnyCallsign").checked           = settings.other.allowAnyCallsign;
     document.getElementById("aprs_is.messagesToRF").checked             = settings.aprs_is.messagesToRF;
     document.getElementById("aprs_is.objectsToRF").checked              = settings.aprs_is.objectsToRF;
     document.getElementById("aprs_is.server").value                     = settings.aprs_is.server;

--- a/data_embed/script.js
+++ b/data_embed/script.js
@@ -251,8 +251,6 @@ function loadSettings(settings) {
     RebootModeCheckbox.checked  = settings.other.rebootMode;
     RebootModeTime.disabled     = !RebootModeCheckbox.check;
 
-    document.getElementById("other.allowAnyCallsign").checked           = settings.other.allowAnyCallsign;
-
     // WiFi Auto AP
     document.getElementById("wifi.autoAP.enabled").checked              = settings.wifi.autoAP.enabled;
     document.getElementById("wifi.autoAP.password").value               = settings.wifi.autoAP.password;

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -177,6 +177,7 @@ public:
     int                     rememberStationTime;
     bool                    rebootMode;
     int                     rebootModeTime;
+    bool                    allowAnyCallsign;
     int                     startupDelay;
     String                  personalNote;
     String                  blacklist;

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -174,10 +174,10 @@ class Configuration {
 public:
     String                  callsign;
     String                  tacticalCallsign;
+    bool                    allowAnyCallsign;
     int                     rememberStationTime;
     bool                    rebootMode;
     int                     rebootModeTime;
-    bool                    allowAnyCallsign;
     int                     startupDelay;
     String                  personalNote;
     String                  blacklist;

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -183,6 +183,7 @@ bool Configuration::writeFile() {
         data["other"]["rebootModeTime"]             = rebootModeTime;
 
         data["other"]["rememberStationTime"]        = rememberStationTime;
+        data["other"]["allowAnyCallsign"]           = allowAnyCallsign;
 
         serializeJson(data, configFile);
         configFile.close();
@@ -420,6 +421,9 @@ bool Configuration::readFile() {
         if (data["other"]["rememberStationTime"].isNull()) needsRewrite = true;
         rememberStationTime             = data["other"]["rememberStationTime"] | 30;
 
+        if (data["other"]["allowAnyCallsign"].isNull()) needsRewrite = true;
+        allowAnyCallsign                = data["other"]["allowAnyCallsign"] | false;
+
         if (wifiAPs.size() == 0) { // If we don't have any WiFi's from config we need to add "empty" SSID for AUTO AP
             WiFi_AP wifiap;
             wifiap.ssid = "";
@@ -564,6 +568,7 @@ void Configuration::setDefaultValues() {
     rebootModeTime                  = 0;
 
     rememberStationTime             = 30;
+    allowAnyCallsign                = false;
 
     Serial.println("New Data Created... All is Written!");
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -432,6 +432,7 @@ namespace Utils {
     bool callsignIsValid(const String& callsign) {
         if (callsign == "WLNK-1") return true;
         int totalCallsignLength = callsign.length();
+        if (Config.allowAnyCallsign) return totalCallsignLength >= 3 && totalCallsignLength <= 9;
         if (totalCallsignLength < 4) return false;
 
         int hyphenIndex         = callsign.indexOf("-");

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -431,8 +431,8 @@ namespace Utils {
 
     bool callsignIsValid(const String& callsign) {
         if (callsign == "WLNK-1") return true;
+        if (Config.allowAnyCallsign) return callsign.length() >= 3 && callsign.length() <= 9;
         int totalCallsignLength = callsign.length();
-        if (Config.allowAnyCallsign) return totalCallsignLength >= 3 && totalCallsignLength <= 9;
         if (totalCallsignLength < 4) return false;
 
         int hyphenIndex         = callsign.indexOf("-");

--- a/src/web_utils.cpp
+++ b/src/web_utils.cpp
@@ -306,6 +306,7 @@ namespace WEB_Utils {
         Config.ntp.gmtCorrection            = getParamFloatSafe("ntp.gmtCorrection", Config.ntp.gmtCorrection);
 
         Config.rememberStationTime          = getParamIntSafe("other.rememberStationTime", Config.rememberStationTime);
+        Config.allowAnyCallsign             = request->hasParam("other.allowAnyCallsign", true);
 
         bool saveSuccess = Config.writeFile();
 


### PR DESCRIPTION
This PR adds a toggle to the APRS-IS section of the web interface letting the iGate operator opt in to accepting tactical callsigns from stations it hears (trackers, digipeaters, etc.) — otherwise strict amateur-radio format validation stays on and packets from non-standard callsigns get rejected/not uploaded. It's controlled per-gateway, so each iGate operator decides individually whether their gateway will relay tactical-callsign traffic; it doesn't change default behavior for anyone who leaves it off.

<img width="1275" height="120" alt="Screenshot 2026-08-16 at 7 42 58 PM" src="https://github.com/user-attachments/assets/db244d0c-ec75-495d-9a3e-9fe1dd1d0ec0" />


