### PR TITLE
Add RAK3312/RAK3112 (ESP32-S3 + SX1262) board variant

### DIFF
--- a/variants/RAK3112/board_pinout.h
+++ b/variants/RAK3112/board_pinout.h
@@ -1,0 +1,39 @@
+/* Copyright (C) 2025 Ricardo Guzman - CA2RXU
+ *
+ * This file is part of LoRa APRS iGate.
+ *
+ * LoRa APRS iGate is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LoRa APRS iGate is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LoRa APRS iGate. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef BOARD_PINOUT_H_
+#define BOARD_PINOUT_H_
+
+    //  LoRa Radio
+    #define HAS_SX1262
+    #define HAS_TCXO
+    #define RADIO_SCLK_PIN      5
+    #define RADIO_MISO_PIN      3
+    #define RADIO_MOSI_PIN      6
+    #define RADIO_CS_PIN        7
+    #define RADIO_RST_PIN       8
+    #define RADIO_DIO1_PIN      47
+    #define RADIO_BUSY_PIN      48
+    #define RADIO_WAKEUP_PIN        RADIO_DIO1_PIN
+    #define GPIO_WAKEUP_PIN         GPIO_SEL_47
+
+    //  Aditional Config
+    #define INTERNAL_LED_PIN    46
+    #define BATTERY_PIN         1
+
+#endif

--- a/variants/RAK3112/platformio.ini
+++ b/variants/RAK3112/platformio.ini
@@ -1,0 +1,15 @@
+[env:RAK3112]
+board = esp32-s3-devkitc-1
+board_build.mcu = esp32s3
+board_build.arduino.memory_type = qio_opi
+board_upload.flash_size = 16MB
+build_flags =
+	${common.build_flags}
+	${common.usb_flags}
+	-D RADIOLIB_EXCLUDE_LR11X0=1
+	-D RADIOLIB_EXCLUDE_SX127X=1
+	-D RADIOLIB_EXCLUDE_SX128X=1
+	-D BOARD_HAS_PSRAM
+	-D RAK3112
+lib_deps =
+	${common.lib_deps}

--- a/variants/RAK3312/board_pinout.h
+++ b/variants/RAK3312/board_pinout.h
@@ -1,0 +1,52 @@
+/* Copyright (C) 2025 Ricardo Guzman - CA2RXU
+ *
+ * This file is part of LoRa APRS iGate.
+ *
+ * LoRa APRS iGate is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LoRa APRS iGate is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LoRa APRS iGate. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef BOARD_PINOUT_H_
+#define BOARD_PINOUT_H_
+
+    //  LoRa Radio
+    #define HAS_SX1262
+    #define HAS_TCXO
+    #define RADIO_SCLK_PIN      5
+    #define RADIO_MISO_PIN      3
+    #define RADIO_MOSI_PIN      6
+    #define RADIO_CS_PIN        7
+    #define RADIO_RST_PIN       8
+    #define RADIO_DIO1_PIN      47
+    #define RADIO_BUSY_PIN      48
+    #define RADIO_WAKEUP_PIN        RADIO_DIO1_PIN
+    #define GPIO_WAKEUP_PIN         GPIO_SEL_47
+
+    #define RADIO_HAS_RF_SWITCH //  ANT_SW - antenna switch/PA power enable
+    #define RADIO_RF_SWITCH     4
+
+    //  Base Board Power
+    #define VEXT_CTRL_PIN       14  //  3V3_EN - powers GPS on Base Board
+    #define VEXT_CTRL_ON_STATE  HIGH
+
+    //  GPS
+    #define HAS_GPS
+    #define GPS_BAUDRATE        9600
+    #define GPS_RX              43
+    #define GPS_TX              44
+
+    //  Aditional Config
+    #define INTERNAL_LED_PIN    46
+    #define BATTERY_PIN         1
+
+#endif

--- a/variants/RAK3312/platformio.ini
+++ b/variants/RAK3312/platformio.ini
@@ -1,0 +1,15 @@
+[env:RAK3312]
+board = esp32-s3-devkitc-1
+board_build.mcu = esp32s3
+board_build.arduino.memory_type = qio_opi
+board_upload.flash_size = 16MB
+build_flags =
+	${common.build_flags}
+	${common.usb_flags}
+	-D RADIOLIB_EXCLUDE_LR11X0=1
+	-D RADIOLIB_EXCLUDE_SX127X=1
+	-D RADIOLIB_EXCLUDE_SX128X=1
+	-D BOARD_HAS_PSRAM
+	-D RAK3312
+lib_deps =
+	${common.lib_deps}


### PR DESCRIPTION
RAK3312/RAK3112 are ESP32-S3 boards. There are lots of RAK19007 based projects. This allows people to use those with the RAK3312/3112.