### PR TITLE
display: fix SCREEN_HEIGHT definition and maxLines for SH1106 OLED

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -57,19 +57,20 @@
             String lastEpaperText;
         #else
             #include <Adafruit_GFX.h>
+            #if defined RPC_LORA_DIGIGATE_1W
+                #define SCREEN_HEIGHT 32
+            #else
+                #define SCREEN_HEIGHT 64
+            #endif
+
             #ifdef HAS_SH1106
                 #include <Adafruit_SH110X.h>
-                Adafruit_SH1106G display(128, 64, &Wire, OLED_RST);
+                Adafruit_SH1106G display(128, SCREEN_HEIGHT, &Wire, OLED_RST);
             #else
                 #include <Adafruit_SSD1306.h>
                 #ifdef HELTEC_WSL_V3_DISPLAY
-                    Adafruit_SSD1306 display(128, 64, &Wire1, OLED_RST);
+                    Adafruit_SSD1306 display(128, SCREEN_HEIGHT, &Wire1, OLED_RST);
                 #else
-                    #if defined RPC_LORA_DIGIGATE_1W
-                        #define SCREEN_HEIGHT 32
-                    #else
-                        #define SCREEN_HEIGHT 64
-                    #endif
                     Adafruit_SSD1306 display(128, SCREEN_HEIGHT, &Wire, OLED_RST);
                 #endif
             #endif
@@ -107,6 +108,8 @@ void displaySetup() {
                 maxLines = 6;
             #elif (SCREEN_HEIGHT == 32)
                 maxLines = 3;
+            #else
+                maxLines = 6;
             #endif
             #ifdef HAS_EPAPER
                 display.landscape();


### PR DESCRIPTION
#### Summary
In recent updates introducing 32px height OLEDs (`RPC_LORA_DIGIGATE_1W`), `#define SCREEN_HEIGHT` was placed inside the nested `#else` block reserved only for default `Adafruit_SSD1306` displays.

As a result:
1. For boards using `Adafruit_SH1106G` (e.g. TTGO T-Beam S3 Supreme, ESP32 9M2IBR) and `HELTEC_WSL_V3_DISPLAY`, `SCREEN_HEIGHT` was left undefined.
2. In `displaySetup()`, `maxLines` was never set (remaining `0`).
3. In `displayShow()`, only the header/callsign in size 2 font was drawn because the loop for printing the lines (`for (int i = 0; i < maxLines; i++)`) executed 0 times.

#### Changes
- Defined `SCREEN_HEIGHT` universally for GFX displays before driver selection in `src/display.cpp`.
- Added `#else maxLines = 6;` fallback in `displaySetup()`.
