### PR TITLE
digi: substitute WIDE2-n by exact path token instead of substring

### DIFF
--- a/src/digi_utils.cpp
+++ b/src/digi_utils.cpp
@@ -42,6 +42,17 @@ extern bool             backupDigiMode;
 
 namespace DIGI_Utils {
 
+    static int pathTokenIndex(const String& path, const String& token) {
+        unsigned int start = 0;
+        while (start < path.length()) {
+            int end = path.indexOf(",", start);
+            if (end == -1) end = path.length();
+            if (path.substring(start, end) == token) return start;
+            start = end + 1;
+        }
+        return -1;
+    }
+
     String cleanPath(String path) {
         String terms[] = {"WIDE1*,", "WIDE2*,", "*"};
         for (String term : terms) {
@@ -93,13 +104,13 @@ namespace DIGI_Utils {
                 if (tempPath.indexOf("*") != -1 ) return "";                                // "*" shouldn't be in WIDE1-1 (only) type of packet
                 tempPath.replace("WIDE1-1", stationCallsign + "*");
             } else if (tempPath.indexOf("WIDE2-") != -1 && digiMode == 2) {                 // WIDE2-n Digipeater
-                tempPath = cleanPath(path);
-                if (tempPath.indexOf("WIDE2-1") != -1) {
-                    tempPath.replace("WIDE2-1", stationCallsign + "*");
-                } else if (tempPath.indexOf("WIDE2-2") != -1) {
-                    tempPath.replace("WIDE2-2", stationCallsign + "*,WIDE2-1");
+                int idx = pathTokenIndex(tempPath, "WIDE2-1");
+                if (idx != -1) {
+                    tempPath = tempPath.substring(0, idx) + stationCallsign + "*" + tempPath.substring(idx + 7);
                 } else {
-                    return "";
+                    idx = pathTokenIndex(tempPath, "WIDE2-2");
+                    if (idx == -1) return "";
+                    tempPath = tempPath.substring(0, idx) + stationCallsign + "*,WIDE2-1" + tempPath.substring(idx + 7);
                 }
             } else if (digiMode == 3) {                                                     // Repeat if station callsign is in path (free to repeat).
                 tempPath = processMode3Path(tempPath, stationCallsign);


### PR DESCRIPTION
Fixes #443.

### Problem

`cleanPath()` removes a single occurrence per term, so an asterisk belonging to an earlier consumed hop can survive:

```cpp
String terms[] = {"WIDE1*,", "WIDE2*,", "*"};
for (String term : terms) {
    int index = path.indexOf(term);
    if (index != -1) path.remove(index, term.length());   // one occurrence only
}
```

`indexOf("WIDE2-1")` then matches *inside* an already-consumed `WIDE2-1*`, and `replace()` inserts the station callsign with its own asterisk directly in front of the leftover one:

```
in  : F1ZCJ-3>APFD11,F6DEV*,F6DEV-11,WIDE2-1*,WIDE3-3:!4321.45N/00225.50E#
out : F1ZCJ-3>APFD11,F6DEV,F6DEV-11,F4MLV-10**,WIDE3-3:!4321.45N/00225.50E#
                                    ^^^^^^^^^^
```

The malformed `**` is the visible symptom. The underlying issue is that `WIDE2-1*` is an **already used** hop and gets consumed a second time.

Note also that `cleanPath()` erased the asterisk on `F6DEV`, losing the record that this station had digipeated the frame.

### Change

Match an exact comma-delimited token and substitute at that index, the way `processMode3Path()` already does in this same file. Other asterisks are left untouched. One file, +17/−6.

### Verification

Built with `pio run -e ttgo-lora32-v21` — success, no warnings introduced.

Behaviour on the three inputs that matter:

```
F6DEV*,F6DEV-11,WIDE2-1*,WIDE3-3  ->  not digipeated   (hop already used)
F6DEV*,F6DEV-11,WIDE2-1,WIDE3-3   ->  F6DEV*,F6DEV-11,F4MLV-10*,WIDE3-3
F6DEV*,F6DEV-11,WIDE2-2,WIDE3-3   ->  F6DEV*,F6DEV-11,F4MLV-10*,WIDE2-1,WIDE3-3
```

Modes 1 and 3, cross-frequency digipeating and the remaining mode 2 paths are unchanged.

Running on F4MLV-10 (mountain-top digi, mode 2, ~150 frames/h) and F1ZDB-10 since mid-August. Confirmed on the air, e.g. `F4MLV-7>APLRT1,WIDE1-1,WIDE2-1` relayed as `F4MLV-7>APLRT1,F4MLV-10*,WIDE2-1`.

73